### PR TITLE
Kpi values are not string but specific classes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
   hooks:
   - id: ruff
 - repo: https://github.com/RobertCraigie/pyright-python
-  rev: v1.1.325
+  rev: v1.1.327
   hooks:
   - id: pyright
     name: pyright (system)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,9 +21,8 @@ dependencies = [
     "alembic == 1.11.3",
     "fastapi[all] == 0.101.1",
     "fastapi-pagination == 0.12.9",
-    "marshmallow == 3.20.1",
-    "marshmallow-sqlalchemy == 0.29.0",
-    "psutil ==5.9.5",
+    "psutil == 5.9.5",
+    "pydantic == 2.3.0", # this is also a sub-dep of fastapi but we rely a lot on it
     "python-dateutil == 2.8.2",
     "PyYAML == 6.0.1",
     "SQLAlchemy == 2.0.20",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -39,7 +39,7 @@ lint = [
     "ruff == 0.0.285",
 ]
 check = [
-    "pyright == 1.1.325",
+    "pyright == 1.1.327",
 ]
 test = [
     "coverage == 7.2.7",

--- a/backend/src/offspot_metrics_backend/business/kpis/content_popularity.py
+++ b/backend/src/offspot_metrics_backend/business/kpis/content_popularity.py
@@ -1,5 +1,4 @@
-from json import dumps
-
+from pydantic import BaseModel, RootModel
 from sqlalchemy import desc, func, select
 from sqlalchemy.orm import Session
 
@@ -13,7 +12,18 @@ from offspot_metrics_backend.db.models import (
     IndicatorDimension,
     IndicatorPeriod,
     IndicatorRecord,
+    KpiValue,
 )
+
+
+class ContentPopularityItem(BaseModel):
+    content: str
+    count: int
+    percentage: float
+
+
+class ContentPopularityValue(RootModel[list[ContentPopularityItem]], KpiValue):
+    pass
 
 
 class ContentPopularity(Kpi):
@@ -25,13 +35,13 @@ class ContentPopularity(Kpi):
 
     unique_id = 2001
 
-    def get_value(
+    def compute_value_from_indicators(
         self,
         agg_kind: AggKind,  # noqa: ARG002
         start_ts: int,
         stop_ts: int,
         session: Session,
-    ) -> str:
+    ) -> ContentPopularityValue:
         """For a kind of aggregation (daily, weekly, ...) and a given period, return
         the KPI value."""
 
@@ -48,7 +58,7 @@ class ContentPopularity(Kpi):
         subquery = (
             select(
                 IndicatorDimension.value0.label("content"),
-                func.sum(IndicatorRecord.value).label("count"),
+                func.sum(IndicatorRecord.value).label("content_count"),
             )
             .join(IndicatorRecord)
             .join(IndicatorPeriod)
@@ -58,20 +68,33 @@ class ContentPopularity(Kpi):
             .group_by("content")
         ).subquery("content_with_count")
 
-        query = select(subquery.c.count, subquery.c.content).order_by(
-            desc(subquery.c.count), subquery.c.content
+        query = select(subquery.c.content_count, subquery.c.content).order_by(
+            desc(subquery.c.content_count), subquery.c.content
         )
 
-        return dumps(
+        return ContentPopularityValue.model_validate(
             [
-                {
-                    "content": record.content,
-                    "count": record.count,
-                    "percentage": round(int(str(record.count)) * 100 / total_count, 2),
-                }
+                ContentPopularityItem(
+                    content=record.content,
+                    count=record.content_count,
+                    percentage=round(record.content_count * 100 / total_count, 2),
+                )
                 for record in session.execute(query)
             ]
         )
+
+
+class ContentObjectPopularityItem(BaseModel):
+    content: str
+    item: str
+    count: int
+    percentage: float
+
+
+class ContentObjectPopularityValue(
+    KpiValue, RootModel[list[ContentObjectPopularityItem]]
+):
+    pass
 
 
 class ContentObjectPopularity(Kpi):
@@ -83,13 +106,13 @@ class ContentObjectPopularity(Kpi):
 
     unique_id = 2002
 
-    def get_value(
+    def compute_value_from_indicators(
         self,
         agg_kind: AggKind,  # noqa: ARG002
         start_ts: int,
         stop_ts: int,
         session: Session,
-    ) -> str:
+    ) -> ContentObjectPopularityValue:
         """For a kind of aggregation (daily, weekly, ...) and a given period, return
         the KPI value."""
 
@@ -107,7 +130,7 @@ class ContentObjectPopularity(Kpi):
             select(
                 IndicatorDimension.value0.label("content"),
                 IndicatorDimension.value1.label("item"),
-                func.sum(IndicatorRecord.value).label("count"),
+                func.sum(IndicatorRecord.value).label("item_count"),
             )
             .join(IndicatorRecord)
             .join(IndicatorPeriod)
@@ -118,19 +141,19 @@ class ContentObjectPopularity(Kpi):
         ).subquery("content_with_count")
 
         query = (
-            select(subquery.c.count, subquery.c.content, subquery.c.item)
-            .order_by(desc(subquery.c.count), subquery.c.content, subquery.c.item)
+            select(subquery.c.item_count, subquery.c.content, subquery.c.item)
+            .order_by(desc(subquery.c.item_count), subquery.c.content, subquery.c.item)
             .limit(50)
         )
 
-        return dumps(
+        return ContentObjectPopularityValue.model_validate(
             [
-                {
-                    "content": record.content,
-                    "item": record.item,
-                    "count": record.count,
-                    "percentage": round(int(str(record.count)) * 100 / total_count, 2),
-                }
+                ContentObjectPopularityItem(
+                    content=record.content,
+                    item=record.item,
+                    count=record.item_count,
+                    percentage=round(record.item_count * 100 / total_count, 2),
+                )
                 for record in session.execute(query)
             ]
         )

--- a/backend/src/offspot_metrics_backend/business/kpis/kpi.py
+++ b/backend/src/offspot_metrics_backend/business/kpis/kpi.py
@@ -3,6 +3,7 @@ import abc
 from sqlalchemy.orm import Session
 
 from offspot_metrics_backend.business.agg_kind import AggKind
+from offspot_metrics_backend.db.models import KpiValue
 
 
 class Kpi(abc.ABC):
@@ -11,9 +12,9 @@ class Kpi(abc.ABC):
     unique_id = 2000  # this ID is unique to each kind of kpi
 
     @abc.abstractmethod
-    def get_value(
+    def compute_value_from_indicators(
         self, agg_kind: AggKind, start_ts: int, stop_ts: int, session: Session
-    ) -> str:
-        """For a kind of aggregation (daily, weekly, ...) and a given period, return
-        the KPI value."""
+    ) -> KpiValue:
+        """For a kind of aggregation (daily, weekly, ...) and a given period, compute
+        the KPI value based on indicators present in DB."""
         ...  # pragma: no cover

--- a/backend/src/offspot_metrics_backend/business/kpis/processor.py
+++ b/backend/src/offspot_metrics_backend/business/kpis/processor.py
@@ -98,7 +98,9 @@ class Processor:
         Existing KPI values are updated in DB. New ones are created.
         Old ones are deleted"""
         values: list[Value] = Persister.get_kpi_values(
-            kpi_id=kpi.unique_id, agg_kind=agg_kind, session=session
+            kpi_id=kpi.unique_id,
+            agg_kind=agg_kind,
+            session=session,
         )
         current_agg_value = now.get_truncated_value(agg_kind)
         aggregations_to_keep = Processor.get_aggregations_to_keep(agg_kind, now)
@@ -116,7 +118,7 @@ class Processor:
             if value.agg_value == current_agg_value:
                 # update the existing KPI value
                 value_updated = True
-                value.kpi_value = kpi.get_value(
+                value.kpi_value = kpi.compute_value_from_indicators(
                     agg_kind=agg_kind,
                     start_ts=timestamps.start,
                     stop_ts=timestamps.stop,
@@ -133,7 +135,7 @@ class Processor:
             # create a new KPI value since there is no existing one
             value = Value(
                 agg_value=current_agg_value,
-                kpi_value=kpi.get_value(
+                kpi_value=kpi.compute_value_from_indicators(
                     agg_kind=agg_kind,
                     start_ts=timestamps.start,
                     stop_ts=timestamps.stop,

--- a/backend/src/offspot_metrics_backend/business/kpis/value.py
+++ b/backend/src/offspot_metrics_backend/business/kpis/value.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass
 
+from offspot_metrics_backend.db.models import KpiValue
+
 
 @dataclass
 class Value:
     """A dataclass to hold KPI value for a given aggregation value"""
 
     agg_value: str
-    kpi_value: str
+    kpi_value: KpiValue

--- a/backend/src/offspot_metrics_backend/db/persister.py
+++ b/backend/src/offspot_metrics_backend/db/persister.py
@@ -10,7 +10,7 @@ from offspot_metrics_backend.db.models import IndicatorDimension as DimensionDb
 from offspot_metrics_backend.db.models import IndicatorPeriod as PeriodDb
 from offspot_metrics_backend.db.models import IndicatorRecord as RecordDb
 from offspot_metrics_backend.db.models import IndicatorState as StateDb
-from offspot_metrics_backend.db.models import KpiValue as KpiValueDb
+from offspot_metrics_backend.db.models import KpiRecord, KpiValue
 
 
 class Persister:
@@ -114,15 +114,18 @@ class Persister:
 
     @classmethod
     def get_kpi_values(
-        cls, kpi_id: int, agg_kind: AggKind, session: Session
+        cls,
+        kpi_id: int,
+        agg_kind: AggKind,
+        session: Session,
     ) -> list[Value]:
         """Return all KPI values for a given KPI and a given kind of period"""
         return [
             Value(agg_value=dbValue.agg_value, kpi_value=dbValue.kpi_value)
             for dbValue in session.execute(
-                sa.select(KpiValueDb)
-                .where(KpiValueDb.kpi_id == kpi_id)
-                .where(KpiValueDb.agg_kind == agg_kind.value)
+                sa.select(KpiRecord)
+                .where(KpiRecord.kpi_id == kpi_id)
+                .where(KpiRecord.agg_kind == agg_kind.value)
             ).scalars()
         ]
 
@@ -132,10 +135,10 @@ class Persister:
     ) -> None:
         """Delete a KPI value for a given KPI, kind of period and period"""
         session.execute(
-            sa.delete(KpiValueDb)
-            .where(KpiValueDb.kpi_id == kpi_id)
-            .where(KpiValueDb.agg_kind == agg_kind.value)
-            .where(KpiValueDb.agg_value == agg_value)
+            sa.delete(KpiRecord)
+            .where(KpiRecord.kpi_id == kpi_id)
+            .where(KpiRecord.agg_kind == agg_kind.value)
+            .where(KpiRecord.agg_value == agg_value)
         )
 
     @classmethod
@@ -144,15 +147,15 @@ class Persister:
         kpi_id: int,
         agg_kind: AggKind,
         agg_value: str,
-        kpi_value: str,
+        kpi_value: KpiValue,
         session: Session,
     ) -> None:
         """Update a KPI value for a given KPI, kind of period and period"""
         obj = session.execute(
-            sa.select(KpiValueDb)
-            .where(KpiValueDb.kpi_id == kpi_id)
-            .where(KpiValueDb.agg_kind == agg_kind.value)
-            .where(KpiValueDb.agg_value == agg_value)
+            sa.select(KpiRecord)
+            .where(KpiRecord.kpi_id == kpi_id)
+            .where(KpiRecord.agg_kind == agg_kind.value)
+            .where(KpiRecord.agg_value == agg_value)
         ).scalar_one()
         obj.kpi_value = kpi_value
 
@@ -162,12 +165,12 @@ class Persister:
         kpi_id: int,
         agg_kind: AggKind,
         agg_value: str,
-        kpi_value: str,
+        kpi_value: KpiValue,
         session: Session,
     ) -> None:
         """Add a KPI value for a given KPI, kind of period and period"""
         session.add(
-            KpiValueDb(
+            KpiRecord(
                 kpi_id=kpi_id,
                 agg_kind=agg_kind.value,
                 agg_value=agg_value,

--- a/backend/src/offspot_metrics_backend/routes/aggregations.py
+++ b/backend/src/offspot_metrics_backend/routes/aggregations.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from fastapi import APIRouter
 from sqlalchemy import select
 
-from offspot_metrics_backend.db.models import KpiValue
+from offspot_metrics_backend.db.models import KpiRecord
 from offspot_metrics_backend.routes import DbSession
 
 router = APIRouter(
@@ -42,7 +42,7 @@ class Aggregations:
 def aggregations(
     session: DbSession,
 ) -> Aggregations:
-    query = select(KpiValue.agg_kind, KpiValue.agg_value).distinct()
+    query = select(KpiRecord.agg_kind, KpiRecord.agg_value).distinct()
 
     return Aggregations(
         aggregations=[

--- a/backend/src/offspot_metrics_backend/routes/kpis.py
+++ b/backend/src/offspot_metrics_backend/routes/kpis.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import APIRouter, HTTPException, Query
 from sqlalchemy import select
 
 from offspot_metrics_backend.business.agg_kind import AggKind
-from offspot_metrics_backend.db.models import KpiValue as DbKpiValue
+from offspot_metrics_backend.db.models import KpiRecord
 from offspot_metrics_backend.routes import DbSession
 
 router = APIRouter(
@@ -19,7 +19,7 @@ class KpiValue:
     """A KPI value with its ID"""
 
     kpi_id: int
-    value: str
+    value: Any
 
 
 @router.get(
@@ -38,10 +38,10 @@ async def kpi_values(
     session: DbSession,
 ) -> KpiValue:
     query = (
-        select(DbKpiValue.kpi_id, DbKpiValue.kpi_value)
-        .where(DbKpiValue.kpi_id == kpi_id)
-        .where(DbKpiValue.agg_value == agg_value)
-        .where(DbKpiValue.agg_kind == agg_kind)
+        select(KpiRecord.kpi_id, KpiRecord.kpi_value)
+        .where(KpiRecord.kpi_id == kpi_id)
+        .where(KpiRecord.agg_value == agg_value)
+        .where(KpiRecord.agg_kind == agg_kind)
     )
 
     item = session.execute(query).first()

--- a/backend/src/offspot_metrics_backend/simulator.py
+++ b/backend/src/offspot_metrics_backend/simulator.py
@@ -101,7 +101,7 @@ def clear_db():
             session.execute(delete(dbm.IndicatorState))
             session.execute(delete(dbm.IndicatorDimension))
             session.execute(delete(dbm.IndicatorPeriod))
-            session.execute(delete(dbm.KpiValue))
+            session.execute(delete(dbm.KpiRecord))
 
 
 def rand_sim_update_now(now: datetime) -> datetime:

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -55,7 +55,7 @@ def call_alembic(ctx: Context, cmd: str, *, test_db: bool = False):
     # this won't be needed once https://github.com/pyinvoke/invoke/issues/170 will be
     # implemented and we will be able to call alembic task from other related tasks
 
-    with ctx.cd("src"):
+    with ctx.cd("src/offspot_metrics_backend"):
         ctx.run(
             f"alembic {cmd}",
             pty=use_pty,

--- a/backend/tests/unit/business/kpis/conftest.py
+++ b/backend/tests/unit/business/kpis/conftest.py
@@ -5,8 +5,8 @@ from typing import TypeAlias
 
 import pytest
 from sqlalchemy.orm import Session
+from tests.unit.conftest import DummyKpi
 
-from offspot_metrics_backend.business.agg_kind import AggKind
 from offspot_metrics_backend.business.indicators.content_visit import (
     ContentHomeVisit,
     ContentItemVisit,
@@ -30,23 +30,6 @@ NoneGenerator: TypeAlias = Generator[None, None, None]
 @pytest.fixture()
 def processor(init_datetime: datetime) -> ProcessorGenerator:
     yield Processor(Period(init_datetime))
-
-
-class DummyKpi(Kpi):
-    """A dummy KPI which is not using indicators at all to simplify testing"""
-
-    unique_id = -2001  # this ID is unique to each kind of kpi
-
-    def get_value(
-        self,
-        agg_kind: AggKind,
-        start_ts: int,
-        stop_ts: int,
-        session: Session,  # noqa: ARG002
-    ) -> str:
-        """For a kind of aggregation (daily, weekly, ...) and a given period, return
-        the KPI value."""
-        return f"{agg_kind.value} - {start_ts} - {stop_ts}"
 
 
 @pytest.fixture()

--- a/backend/tests/unit/business/kpis/test_content_popularity.py
+++ b/backend/tests/unit/business/kpis/test_content_popularity.py
@@ -3,27 +3,64 @@ from sqlalchemy.orm import Session
 from offspot_metrics_backend.business.agg_kind import AggKind
 from offspot_metrics_backend.business.kpis.content_popularity import (
     ContentObjectPopularity,
+    ContentObjectPopularityItem,
+    ContentObjectPopularityValue,
     ContentPopularity,
+    ContentPopularityItem,
+    ContentPopularityValue,
 )
 
+CONTENT_POPULARITY_VALUES_AS_OBJECT = ContentPopularityValue.model_validate(
+    [
+        ContentPopularityItem(content="value1", count=18, percentage=56.25),
+        ContentPopularityItem(content="value2", count=14, percentage=43.75),
+    ]
+)
 
-def test_content_popularity(dbsession: Session, kpi_dataset: None):  # noqa: ARG001
-    kpi = ContentPopularity()
-    assert kpi.get_value(
-        agg_kind=AggKind.DAY, start_ts=2, stop_ts=3, session=dbsession
-    ) == (
-        '[{"content": "value1", "count": 18, "percentage": 56.25}, {"content": '
-        '"value2", "count": 14, "percentage": 43.75}]'
+CONTENT_POPULARITY_VALUES_AS_DICT = [
+    {"content": "value1", "count": 18, "percentage": 56.25},
+    {"content": "value2", "count": 14, "percentage": 43.75},
+]
+
+CONTENT_OBJECT_POPULARITY_VALUES_AS_OBJECT = (
+    ContentObjectPopularityValue.model_validate(
+        [
+            ContentObjectPopularityItem(
+                content="value1", item="value2", count=22, percentage=73.33
+            ),
+            ContentObjectPopularityItem(
+                content="value1", item="value3", count=8, percentage=26.67
+            ),
+        ]
     )
+)
+
+CONTENT_OBJECT_POPULARITY_VALUES_AS_DICT = [
+    {"content": "value1", "item": "value2", "count": 22, "percentage": 73.33},
+    {"content": "value1", "item": "value3", "count": 8, "percentage": 26.67},
+]
 
 
-def test_content_object_popularity(
+def test_content_popularity_compute(
+    dbsession: Session, kpi_dataset: None  # noqa: ARG001
+):
+    kpi = ContentPopularity()
+    value = kpi.compute_value_from_indicators(
+        agg_kind=AggKind.DAY, start_ts=2, stop_ts=3, session=dbsession
+    )
+    assert value == CONTENT_POPULARITY_VALUES_AS_OBJECT
+    assert ContentPopularityValue.model_dump(value) == CONTENT_POPULARITY_VALUES_AS_DICT
+
+
+def test_content_object_popularity_compute(
     dbsession: Session, kpi_dataset: None  # noqa: ARG001
 ):
     kpi = ContentObjectPopularity()
-    assert kpi.get_value(
+    value = kpi.compute_value_from_indicators(
         agg_kind=AggKind.DAY, start_ts=2, stop_ts=3, session=dbsession
-    ) == (
-        '[{"content": "value1", "item": "value2", "count": 22, "percentage": 73.33}, '
-        '{"content": "value1", "item": "value3", "count": 8, "percentage": 26.67}]'
+    )
+    assert value == CONTENT_OBJECT_POPULARITY_VALUES_AS_OBJECT
+    assert (
+        ContentObjectPopularityValue.model_dump(value)
+        == CONTENT_OBJECT_POPULARITY_VALUES_AS_DICT
     )

--- a/backend/tests/unit/business/kpis/test_kpis.py
+++ b/backend/tests/unit/business/kpis/test_kpis.py
@@ -1,8 +1,10 @@
 from datetime import datetime, timedelta
+from typing import cast
 
 import pytest
 from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
+from tests.unit.conftest import DummyKpiValue
 
 from offspot_metrics_backend.business.agg_kind import AggKind
 from offspot_metrics_backend.business.kpis.kpi import Kpi
@@ -10,22 +12,27 @@ from offspot_metrics_backend.business.kpis.processor import Processor
 from offspot_metrics_backend.business.period import Period
 from offspot_metrics_backend.db import count_from_stmt
 from offspot_metrics_backend.db.models import IndicatorPeriod as PeriodDb
-from offspot_metrics_backend.db.models import KpiValue
+from offspot_metrics_backend.db.models import KpiRecord, KpiValue
 
-init_datetime_day_dummyvalue = "D - 1686182400 - 1686268800"
-init_datetime_day_minus_one_dummyvalue = "D - 1686096000 - 1686182400"
-init_datetime_day_plus_one_dummyvalue = "D - 1686268800 - 1686355200"
-init_datetime_day_plus_two_dummyvalue = "D - 1686355200 - 1686441600"
-init_datetime_day_plus_three_dummyvalue = "D - 1686787200 - 1686873600"
-init_datetime_week_dummyvalue = "W - 1685923200 - 1686528000"
-init_datetime_week_plus_one_dummyvalue = "W - 1686528000 - 1687132800"
-init_datetime_month_dummyvalue = "M - 1685577600 - 1688169600"
-init_datetime_year_dummyvalue = "Y - 1672531200 - 1704067200"
 
-previous_datetime_day_dummyvalue = "D - 1672704000 - 1672790400"
-previous_datetime_week_dummyvalue = "W - 1672617600 - 1673222400"
-previous_datetime_month_dummyvalue = "M - 1672531200 - 1675209600"
-previous_datetime_year_dummyvalue = "Y - 1672531200 - 1704067200"
+def get_dummy_value(value: str) -> DummyKpiValue:
+    return DummyKpiValue.model_validate(value)
+
+
+init_datetime_day_dummyvalue = get_dummy_value("D - 1686182400 - 1686268800")
+init_datetime_day_minus_one_dummyvalue = get_dummy_value("D - 1686096000 - 1686182400")
+init_datetime_day_plus_one_dummyvalue = get_dummy_value("D - 1686268800 - 1686355200")
+init_datetime_day_plus_two_dummyvalue = get_dummy_value("D - 1686355200 - 1686441600")
+init_datetime_day_plus_three_dummyvalue = get_dummy_value("D - 1686787200 - 1686873600")
+init_datetime_week_dummyvalue = get_dummy_value("W - 1685923200 - 1686528000")
+init_datetime_week_plus_one_dummyvalue = get_dummy_value("W - 1686528000 - 1687132800")
+init_datetime_month_dummyvalue = get_dummy_value("M - 1685577600 - 1688169600")
+init_datetime_year_dummyvalue = get_dummy_value("Y - 1672531200 - 1704067200")
+
+previous_datetime_day_dummyvalue = get_dummy_value("D - 1672704000 - 1672790400")
+previous_datetime_week_dummyvalue = get_dummy_value("W - 1672617600 - 1673222400")
+previous_datetime_month_dummyvalue = get_dummy_value("M - 1672531200 - 1675209600")
+previous_datetime_year_dummyvalue = get_dummy_value("Y - 1672531200 - 1704067200")
 
 
 @pytest.mark.parametrize(
@@ -85,23 +92,32 @@ def test_get_aggregations_to_keep(
         assert sorted(res) == sorted(expected_periods)
 
 
+def get_kpi_values(dbsession: Session):
+    def get_dummy_key(value: KpiValue) -> DummyKpiValue:
+        return cast(DummyKpiValue, value)
+
+    return sorted(
+        dbsession.execute(select(KpiRecord.kpi_value)).scalars(), key=get_dummy_key
+    )
+
+
 def test_process_tick(
     processor: Processor, dummy_kpi: Kpi, init_datetime: datetime, dbsession: Session
 ) -> None:
     processor.kpis = [dummy_kpi]
-    dbsession.execute(delete(KpiValue))
+    dbsession.execute(delete(KpiRecord))
     processor.process_tick(tick_period=Period(init_datetime), session=dbsession)
-    assert count_from_stmt(dbsession, select(KpiValue)) == 0
+    assert count_from_stmt(dbsession, select(KpiRecord)) == 0
     processor.process_tick(
         tick_period=Period(init_datetime + timedelta(minutes=1)),
         session=dbsession,
     )
-    assert count_from_stmt(dbsession, select(KpiValue)) == 0
+    assert count_from_stmt(dbsession, select(KpiRecord)) == 0
     processor.process_tick(
         tick_period=Period(init_datetime + timedelta(hours=1)), session=dbsession
     )
-    assert count_from_stmt(dbsession, select(KpiValue)) == 3
-    assert sorted(dbsession.execute(select(KpiValue.kpi_value)).scalars()) == sorted(
+    assert count_from_stmt(dbsession, select(KpiRecord)) == 3
+    assert get_kpi_values(dbsession) == sorted(
         [
             init_datetime_day_dummyvalue,
             init_datetime_week_dummyvalue,
@@ -111,8 +127,8 @@ def test_process_tick(
     processor.process_tick(
         tick_period=Period(init_datetime + timedelta(hours=4)), session=dbsession
     )
-    assert count_from_stmt(dbsession, select(KpiValue)) == 3
-    assert sorted(dbsession.execute(select(KpiValue.kpi_value)).scalars()) == sorted(
+    assert count_from_stmt(dbsession, select(KpiRecord)) == 3
+    assert get_kpi_values(dbsession) == sorted(
         [
             init_datetime_day_dummyvalue,
             init_datetime_week_dummyvalue,
@@ -122,8 +138,8 @@ def test_process_tick(
     processor.process_tick(
         tick_period=Period(init_datetime + timedelta(days=1)), session=dbsession
     )
-    assert count_from_stmt(dbsession, select(KpiValue)) == 4
-    assert sorted(dbsession.execute(select(KpiValue.kpi_value)).scalars()) == sorted(
+    assert count_from_stmt(dbsession, select(KpiRecord)) == 4
+    assert get_kpi_values(dbsession) == sorted(
         [
             init_datetime_day_dummyvalue,
             init_datetime_week_dummyvalue,
@@ -135,8 +151,8 @@ def test_process_tick(
         tick_period=Period(init_datetime + timedelta(days=1) + timedelta(hours=1)),
         session=dbsession,
     )
-    assert count_from_stmt(dbsession, select(KpiValue)) == 5
-    assert sorted(dbsession.execute(select(KpiValue.kpi_value)).scalars()) == sorted(
+    assert count_from_stmt(dbsession, select(KpiRecord)) == 5
+    assert get_kpi_values(dbsession) == sorted(
         [
             init_datetime_day_dummyvalue,
             init_datetime_day_plus_one_dummyvalue,
@@ -148,8 +164,8 @@ def test_process_tick(
     processor.process_tick(
         tick_period=Period(init_datetime + timedelta(days=2)), session=dbsession
     )
-    assert count_from_stmt(dbsession, select(KpiValue)) == 5
-    assert sorted(dbsession.execute(select(KpiValue.kpi_value)).scalars()) == sorted(
+    assert count_from_stmt(dbsession, select(KpiRecord)) == 5
+    assert get_kpi_values(dbsession) == sorted(
         [
             init_datetime_day_dummyvalue,
             init_datetime_day_plus_one_dummyvalue,
@@ -162,8 +178,8 @@ def test_process_tick(
         tick_period=Period(init_datetime + timedelta(days=2) + timedelta(hours=1)),
         session=dbsession,
     )
-    assert count_from_stmt(dbsession, select(KpiValue)) == 6
-    assert sorted(dbsession.execute(select(KpiValue.kpi_value)).scalars()) == sorted(
+    assert count_from_stmt(dbsession, select(KpiRecord)) == 6
+    assert get_kpi_values(dbsession) == sorted(
         [
             init_datetime_day_dummyvalue,
             init_datetime_day_plus_one_dummyvalue,
@@ -176,8 +192,8 @@ def test_process_tick(
     processor.process_tick(
         tick_period=Period(init_datetime + timedelta(days=7)), session=dbsession
     )
-    assert count_from_stmt(dbsession, select(KpiValue)) == 6
-    assert sorted(dbsession.execute(select(KpiValue.kpi_value)).scalars()) == sorted(
+    assert count_from_stmt(dbsession, select(KpiRecord)) == 6
+    assert get_kpi_values(dbsession) == sorted(
         [
             init_datetime_day_dummyvalue,
             init_datetime_day_plus_one_dummyvalue,
@@ -191,8 +207,8 @@ def test_process_tick(
         tick_period=Period(init_datetime + timedelta(days=7) + timedelta(hours=1)),
         session=dbsession,
     )
-    assert count_from_stmt(dbsession, select(KpiValue)) == 7
-    assert sorted(dbsession.execute(select(KpiValue.kpi_value)).scalars()) == sorted(
+    assert count_from_stmt(dbsession, select(KpiRecord)) == 7
+    assert get_kpi_values(dbsession) == sorted(
         [
             init_datetime_day_plus_one_dummyvalue,
             init_datetime_day_plus_two_dummyvalue,
@@ -209,29 +225,29 @@ def test_restore_kpis_from_almost_empty_db(
     processor: Processor, dummy_kpi: Kpi, init_datetime: datetime, dbsession: Session
 ) -> None:
     processor.kpis = [dummy_kpi]
-    dbsession.execute(delete(KpiValue))
+    dbsession.execute(delete(KpiRecord))
     dbsession.execute(delete(PeriodDb))
 
     processor.restore_from_db(session=dbsession)
-    assert count_from_stmt(dbsession, select(KpiValue)) == 0
+    assert count_from_stmt(dbsession, select(KpiRecord)) == 0
 
     init_period = PeriodDb.from_datetime(init_datetime)
     dbsession.add(init_period)
     processor.restore_from_db(session=dbsession)
-    assert count_from_stmt(dbsession, select(KpiValue)) == 0
+    assert count_from_stmt(dbsession, select(KpiRecord)) == 0
     dbsession.delete(init_period)
 
     minus_1_hour = PeriodDb.from_datetime(init_datetime - timedelta(hours=1))
     dbsession.add(minus_1_hour)
     processor.restore_from_db(session=dbsession)
-    assert count_from_stmt(dbsession, select(KpiValue)) == 3
+    assert count_from_stmt(dbsession, select(KpiRecord)) == 3
     dbsession.delete(minus_1_hour)
 
     minus_1_day = PeriodDb.from_datetime(init_datetime - timedelta(days=1))
     dbsession.add(minus_1_day)
     processor.restore_from_db(session=dbsession)
-    assert count_from_stmt(dbsession, select(KpiValue)) == 4
-    assert sorted(dbsession.execute(select(KpiValue.kpi_value)).scalars()) == sorted(
+    assert count_from_stmt(dbsession, select(KpiRecord)) == 4
+    assert get_kpi_values(dbsession) == sorted(
         [
             init_datetime_day_minus_one_dummyvalue,
             init_datetime_week_dummyvalue,
@@ -248,48 +264,48 @@ def test_restore_kpis_from_filled_db(
     dbsession: Session,
 ) -> None:
     processor.kpis = [dummy_kpi]
-    dbsession.execute(delete(KpiValue))
+    dbsession.execute(delete(KpiRecord))
     dbsession.execute(delete(PeriodDb))
 
     dbsession.add(
-        KpiValue(
+        KpiRecord(
             kpi_id=dummy_kpi.unique_id,
             agg_kind=AggKind.YEAR.value,
             agg_value="2023",
-            kpi_value="whatever",
+            kpi_value=get_dummy_value("whatever"),
         )
     )
 
     dbsession.add(
-        KpiValue(
+        KpiRecord(
             kpi_id=dummy_kpi.unique_id,
             agg_kind=AggKind.MONTH.value,
             agg_value="2023-01",
-            kpi_value="whatever",
+            kpi_value=get_dummy_value("whatever"),
         )
     )
     dbsession.add(
-        KpiValue(
+        KpiRecord(
             kpi_id=dummy_kpi.unique_id,
             agg_kind=AggKind.WEEK.value,
             agg_value="2023 W01",
-            kpi_value="whatever",
+            kpi_value=get_dummy_value("whatever"),
         )
     )
     dbsession.add(
-        KpiValue(
+        KpiRecord(
             kpi_id=dummy_kpi.unique_id,
             agg_kind=AggKind.DAY.value,
             agg_value="2023-01-03",
-            kpi_value="whatever",
+            kpi_value=get_dummy_value("whatever"),
         )
     )
 
     dbsession.add(PeriodDb.from_datetime(previous_datetime))
 
     processor.restore_from_db(session=dbsession)
-    assert count_from_stmt(dbsession, select(KpiValue)) == 4
-    assert sorted(dbsession.execute(select(KpiValue.kpi_value)).scalars()) == sorted(
+    assert count_from_stmt(dbsession, select(KpiRecord)) == 4
+    assert get_kpi_values(dbsession) == sorted(
         [
             previous_datetime_day_dummyvalue,
             previous_datetime_week_dummyvalue,

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -2,9 +2,14 @@ import pathlib
 from collections.abc import Callable, Generator
 
 import pytest
+from pydantic import RootModel
+from sqlalchemy.orm import Session
 
+from offspot_metrics_backend.business.agg_kind import AggKind
+from offspot_metrics_backend.business.kpis.kpi import Kpi
 from offspot_metrics_backend.business.reverse_proxy_config import ReverseProxyConfig
 from offspot_metrics_backend.constants import BackendConf
+from offspot_metrics_backend.db.models import KpiValue
 
 
 @pytest.fixture()
@@ -28,3 +33,28 @@ def reverse_proxy_config() -> (
     yield _reverse_proxy_config
 
     BackendConf.package_conf_file_location = previous_location
+
+
+class DummyKpiValue(RootModel[str], KpiValue):
+    def __lt__(self, other: "DummyKpiValue") -> bool:
+        """Custom comparator just to make tests more easy"""
+        return self.root < other.root
+
+
+class DummyKpi(Kpi):
+    """A dummy KPI which is not using indicators at all to simplify testing"""
+
+    unique_id = -2001  # this ID is unique to each kind of kpi
+
+    def compute_value_from_indicators(
+        self,
+        agg_kind: AggKind,
+        start_ts: int,
+        stop_ts: int,
+        session: Session,  # noqa: ARG002
+    ) -> DummyKpiValue:
+        """For a kind of aggregation (daily, weekly, ...) and a given period, return
+        the KPI value."""
+        return DummyKpiValue.model_validate(
+            f"{agg_kind.value} - {start_ts} - {stop_ts}"
+        )

--- a/backend/tests/unit/routes/conftest.py
+++ b/backend/tests/unit/routes/conftest.py
@@ -8,9 +8,18 @@ from fastapi import FastAPI
 from httpx import AsyncClient
 from sqlalchemy import delete
 from sqlalchemy.orm import Session
+from tests.unit.conftest import DummyKpi, DummyKpiValue
 
+from offspot_metrics_backend.business.kpis.content_popularity import (
+    ContentObjectPopularity,
+    ContentObjectPopularityItem,
+    ContentObjectPopularityValue,
+    ContentPopularity,
+    ContentPopularityItem,
+    ContentPopularityValue,
+)
 from offspot_metrics_backend.business.reverse_proxy_config import ReverseProxyConfig
-from offspot_metrics_backend.db.models import KpiValue
+from offspot_metrics_backend.db.models import KpiRecord
 from offspot_metrics_backend.main import Main
 
 
@@ -38,12 +47,35 @@ async def client(app: FastAPI) -> AsyncGenerator[AsyncClient, Any]:
 
 
 @pytest_asyncio.fixture()  # pyright: ignore
-async def kpis(dbsession: Session) -> AsyncGenerator[list[KpiValue], Any]:
-    dbsession.execute(delete(KpiValue))
+async def kpis(dbsession: Session) -> AsyncGenerator[list[KpiRecord], Any]:
+    dbsession.execute(delete(KpiRecord))
     kpis = [
-        KpiValue(kpi_id=1, agg_kind="D", agg_value="2023-03-01", kpi_value="165"),
-        KpiValue(kpi_id=2, agg_kind="D", agg_value="2023-03-01", kpi_value="123"),
-        KpiValue(kpi_id=1, agg_kind="W", agg_value="2023 W10", kpi_value="199"),
+        KpiRecord(
+            kpi_id=ContentObjectPopularity.unique_id,
+            agg_kind="D",
+            agg_value="2023-03-01",
+            kpi_value=ContentObjectPopularityValue.model_validate(
+                [
+                    ContentObjectPopularityItem(
+                        content="onecontent", item="oneitem", count=12, percentage=23.2
+                    )
+                ]
+            ),
+        ),
+        KpiRecord(
+            kpi_id=ContentPopularity.unique_id,
+            agg_kind="D",
+            agg_value="2023-03-01",
+            kpi_value=ContentPopularityValue.model_validate(
+                [ContentPopularityItem(content="onecontent", count=34, percentage=33.2)]
+            ),
+        ),
+        KpiRecord(
+            kpi_id=DummyKpi.unique_id,
+            agg_kind="W",
+            agg_value="2023 W10",
+            kpi_value=DummyKpiValue.model_validate("199"),
+        ),
     ]
     for kpi in kpis:
         dbsession.add(kpi)

--- a/backend/tests/unit/routes/test_aggregations_endpoints.py
+++ b/backend/tests/unit/routes/test_aggregations_endpoints.py
@@ -3,14 +3,14 @@ from http import HTTPStatus
 import pytest
 from httpx import AsyncClient
 
-from offspot_metrics_backend.db.models import KpiValue
+from offspot_metrics_backend.db.models import KpiRecord
 from offspot_metrics_backend.main import PREFIX
 
 
 @pytest.mark.asyncio
 async def test_aggregations(
     client: AsyncClient,
-    kpis: list[KpiValue],  # noqa: ARG001
+    kpis: list[KpiRecord],  # noqa: ARG001
 ):
     response = await client.get(f"{PREFIX}/aggregations")
     assert response.status_code == HTTPStatus.OK

--- a/backend/tests/unit/routes/test_kpis_endpoints.py
+++ b/backend/tests/unit/routes/test_kpis_endpoints.py
@@ -3,7 +3,7 @@ from http import HTTPStatus
 import pytest
 from httpx import AsyncClient
 
-from offspot_metrics_backend.db.models import KpiValue
+from offspot_metrics_backend.db.models import KpiRecord
 from offspot_metrics_backend.main import PREFIX
 
 
@@ -11,18 +11,35 @@ from offspot_metrics_backend.main import PREFIX
 @pytest.mark.parametrize(
     "kpi_id, agg_kind, agg_value, expected_value",
     [
-        (1, "D", "2023-03-01", "165"),
-        (1, "W", "2023 W10", "199"),
-        (2, "D", "2023-03-01", "123"),
+        (
+            2001,
+            "D",
+            "2023-03-01",
+            [{"content": "onecontent", "count": 34, "percentage": 33.2}],
+        ),
+        (
+            2002,
+            "D",
+            "2023-03-01",
+            [
+                {
+                    "content": "onecontent",
+                    "count": 12,
+                    "item": "oneitem",
+                    "percentage": 23.2,
+                }
+            ],
+        ),
+        (-2001, "W", "2023 W10", "199"),
     ],
 )
-async def test_kpis(
+async def test_kpis_get(
     kpi_id: int,
     agg_kind: str,
     agg_value: str,
     expected_value: str,
     client: AsyncClient,
-    kpis: list[KpiValue],  # noqa: ARG001
+    kpis: list[KpiRecord],  # noqa: ARG001
 ):
     response = await client.get(
         f"{PREFIX}/kpis/{kpi_id}/values?agg_kind={agg_kind}&agg_value={agg_value}"
@@ -38,7 +55,7 @@ async def test_kpis(
 @pytest.mark.asyncio
 async def test_kpis_not_exist(
     client: AsyncClient,
-    kpis: list[KpiValue],  # noqa: ARG001
+    kpis: list[KpiRecord],  # noqa: ARG001
 ):
     response = await client.get(
         f"{PREFIX}/kpis/whatever/values?agg_kind=W&agg_value=whatever"
@@ -49,7 +66,7 @@ async def test_kpis_not_exist(
 @pytest.mark.asyncio
 async def test_kpis_wrong_agg_kind(
     client: AsyncClient,
-    kpis: list[KpiValue],  # noqa: ARG001
+    kpis: list[KpiRecord],  # noqa: ARG001
 ):
     response = await client.get(
         f"{PREFIX}/kpis/whatever/values?agg_kind=whatever&agg_value=whatever"


### PR DESCRIPTION
# Rationale

Fix https://github.com/offspot/metrics/issues/16

# Changes

- Kpi values are now typed properly, for easier usage throughout the codebase
- serialization/deserialization is transparently handled at the DB level (via https://docs.sqlalchemy.org/en/20/core/custom_types.html)
- serialization/deserialization is transparently handled at the API level
- update pyright from 1.1.325 to 1.1.327