### PR TITLE
Add shared files KPI

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -222,6 +222,7 @@ omit = [
   "src/offspot_metrics_backend/main.py", # glue logic
   "src/offspot_metrics_backend/business/processor.py", # glue logic
   "src/offspot_metrics_backend/business/indicators/content_visit.py", # straightforward implementation, pointless to test
+  "src/offspot_metrics_backend/business/indicators/shared_files.py", # straightforward implementation, pointless to test
   "src/offspot_metrics_backend/simulator.py", # developer tool
 ]
 

--- a/backend/src/offspot_metrics_backend/business/indicators/shared_files.py
+++ b/backend/src/offspot_metrics_backend/business/indicators/shared_files.py
@@ -1,0 +1,26 @@
+from typing import cast
+
+from offspot_metrics_backend.business.indicators.dimensions import DimensionsValues
+from offspot_metrics_backend.business.indicators.indicator import Indicator
+from offspot_metrics_backend.business.indicators.recorder import (
+    IntCounterRecorder,
+    Recorder,
+)
+from offspot_metrics_backend.business.inputs.input import Input
+from offspot_metrics_backend.business.inputs.shared_files import SharedFilesOperation
+
+
+class SharedFilesOperations(Indicator):
+    """An indicator counting operations on shared files"""
+
+    unique_id = 1003
+
+    def can_process_input(self, input_: Input) -> bool:
+        return isinstance(input_, SharedFilesOperation)
+
+    def get_new_recorder(self) -> Recorder:
+        return IntCounterRecorder()
+
+    def get_dimensions_values(self, input_: Input) -> DimensionsValues:
+        input_ = cast(SharedFilesOperation, input_)
+        return DimensionsValues(input_.kind, None, None)

--- a/backend/src/offspot_metrics_backend/business/inputs/shared_files.py
+++ b/backend/src/offspot_metrics_backend/business/inputs/shared_files.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from enum import Enum
+
+from offspot_metrics_backend.business.inputs.input import Input
+
+
+class SharedFilesOperationKind(str, Enum):
+    """The various kind of supported aggregations"""
+
+    FILE_CREATED = "FILE_CREATED"
+    FILE_DELETED = "FILE_DELETED"
+
+
+@dataclass
+class SharedFilesOperation(Input):
+    """Input representing an operation on a shared files software (EduPi for now)"""
+
+    # kind of operation (creation or deletion for now)
+    kind: SharedFilesOperationKind

--- a/backend/src/offspot_metrics_backend/business/kpis/shared_files.py
+++ b/backend/src/offspot_metrics_backend/business/kpis/shared_files.py
@@ -1,0 +1,71 @@
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from offspot_metrics_backend.business.agg_kind import AggKind
+from offspot_metrics_backend.business.indicators.shared_files import (
+    SharedFilesOperations,
+)
+from offspot_metrics_backend.business.inputs.shared_files import (
+    SharedFilesOperationKind,
+)
+from offspot_metrics_backend.business.kpis.kpi import Kpi
+from offspot_metrics_backend.db.models import (
+    IndicatorDimension,
+    IndicatorPeriod,
+    IndicatorRecord,
+    KpiValue,
+)
+
+
+class SharedFilesValue(BaseModel, KpiValue):
+    files_created: int
+    files_deleted: int
+
+
+class SharedFiles(Kpi):
+    """A KPI which measures some statistics about shared files (EduPi for now) usage
+
+    Value is a single measure for the period of files added and files removed
+    """
+
+    unique_id = 2005
+
+    def compute_value_from_indicators(
+        self,
+        agg_kind: AggKind,  # noqa: ARG002
+        start_ts: int,
+        stop_ts: int,
+        session: Session,
+    ) -> SharedFilesValue:
+        """For a kind of aggregation (daily, weekly, ...) and a given period, return
+        the KPI value."""
+
+        counts = session.execute(
+            select(
+                IndicatorDimension.value0.label("operation"),
+                func.sum(IndicatorRecord.value).label("total"),
+            )
+            .join(IndicatorRecord)
+            .join(IndicatorPeriod)
+            .where(IndicatorRecord.indicator_id == SharedFilesOperations.unique_id)
+            .where(IndicatorPeriod.timestamp >= start_ts)
+            .where(IndicatorPeriod.timestamp <= stop_ts)
+            .group_by("operation")
+        ).all()
+
+        files_created = 0
+        files_deleted = 0
+        for count_record in counts:
+            if count_record.operation == SharedFilesOperationKind.FILE_CREATED:
+                files_created = count_record.total
+            elif count_record.operation == SharedFilesOperationKind.FILE_DELETED:
+                files_deleted = count_record.total
+            else:
+                # we should never get there except if the enum is modified and we
+                # forget to modify this function
+                raise AttributeError("Unexpected operation found")  # pragma: no cover
+
+        return SharedFilesValue(
+            files_created=files_created, files_deleted=files_deleted
+        )

--- a/backend/src/offspot_metrics_backend/business/reverse_proxy_config.py
+++ b/backend/src/offspot_metrics_backend/business/reverse_proxy_config.py
@@ -90,8 +90,7 @@ class ReverseProxyConfig:
                 self.zim_host = host
             elif self.zim_host != host:
                 self.warnings.append(
-                    f"Ignoring second zim host '{self.zim_host}', only one host"
-                    " supported"
+                    f"Ignoring second zim host '{host}', only one host supported"
                 )
                 return
 

--- a/backend/src/offspot_metrics_backend/business/reverse_proxy_config.py
+++ b/backend/src/offspot_metrics_backend/business/reverse_proxy_config.py
@@ -27,6 +27,7 @@ class ReverseProxyConfig:
     def __init__(self) -> None:
         self.files: dict[str, Any] = {}
         self.zim_host: str | None = None
+        self.edupi_hosts: list[str] = []
         self.zims: dict[str, Any] = {}
         self.warnings: list[str] = []
 
@@ -40,6 +41,9 @@ class ReverseProxyConfig:
 
         for warning in self.warnings:
             logger.warning(warning)
+
+        for host in self.edupi_hosts:
+            logger.info(f"Found EduPi host in {host}")
 
         for host, file in self.files.items():
             logger.info(f"Found File {file} in {host}")
@@ -82,7 +86,16 @@ class ReverseProxyConfig:
         host = match.group("host")
 
         kind = package.get("kind")
-        if kind == "files":
+
+        ident = package.get("ident", None)
+
+        if kind == "app":
+            if ident == "edupi.offspot.kiwix.org":
+                self.edupi_hosts.append(host)
+            else:
+                self.warnings.append(f"Ignoring unknown app ident '{ident}'")
+            return
+        elif kind == "files":
             self.files[host] = {"title": title}
             return
         elif kind == "zim":

--- a/backend/tests/unit/business/kpis/conftest.py
+++ b/backend/tests/unit/business/kpis/conftest.py
@@ -12,6 +12,12 @@ from offspot_metrics_backend.business.indicators.content_visit import (
     ContentItemVisit,
 )
 from offspot_metrics_backend.business.indicators.indicator import Indicator
+from offspot_metrics_backend.business.indicators.shared_files import (
+    SharedFilesOperations,
+)
+from offspot_metrics_backend.business.inputs.shared_files import (
+    SharedFilesOperationKind,
+)
 from offspot_metrics_backend.business.kpis.kpi import Kpi
 from offspot_metrics_backend.business.kpis.processor import Processor
 from offspot_metrics_backend.business.period import Period
@@ -75,6 +81,11 @@ def kpi_dataset(dbsession: Session) -> NoneGenerator:
                     dimension_value0="value1",
                     dimension_value1="value2",
                 ),
+                DataRecord(
+                    indicator=SharedFilesOperations,
+                    value=33,
+                    dimension_value0=SharedFilesOperationKind.FILE_CREATED,
+                ),
             ],
         ),
         Data(
@@ -91,6 +102,11 @@ def kpi_dataset(dbsession: Session) -> NoneGenerator:
                     value=16,
                     dimension_value0="value1",
                     dimension_value1="value2",
+                ),
+                DataRecord(
+                    indicator=SharedFilesOperations,
+                    value=11,
+                    dimension_value0=SharedFilesOperationKind.FILE_DELETED,
                 ),
             ],
         ),
@@ -125,6 +141,16 @@ def kpi_dataset(dbsession: Session) -> NoneGenerator:
                     value=36,
                     dimension_value0="value1",
                     dimension_value1="value4",
+                ),
+                DataRecord(
+                    indicator=SharedFilesOperations,
+                    value=16,
+                    dimension_value0=SharedFilesOperationKind.FILE_CREATED,
+                ),
+                DataRecord(
+                    indicator=SharedFilesOperations,
+                    value=14,
+                    dimension_value0=SharedFilesOperationKind.FILE_DELETED,
                 ),
             ],
         ),

--- a/backend/tests/unit/business/kpis/test_shared_files.py
+++ b/backend/tests/unit/business/kpis/test_shared_files.py
@@ -1,0 +1,35 @@
+from sqlalchemy.orm import Session
+
+from offspot_metrics_backend.business.agg_kind import AggKind
+from offspot_metrics_backend.business.kpis.shared_files import (
+    SharedFiles,
+    SharedFilesValue,
+)
+
+SHARED_FILES_VALUE_AS_OBJECT_1 = SharedFilesValue(files_created=0, files_deleted=11)
+SHARED_FILES_VALUE_AS_OBJECT_2 = SharedFilesValue(files_created=33, files_deleted=11)
+SHARED_FILES_VALUE_AS_OBJECT_3 = SharedFilesValue(files_created=33, files_deleted=0)
+
+SHARED_FILES_VALUE_AS_DICT_1 = {
+    "files_created": 0,
+    "files_deleted": 11,
+}
+
+
+def test_shared_files_compute(dbsession: Session, kpi_dataset: None):  # noqa: ARG001
+    kpi = SharedFiles()
+    value = kpi.compute_value_from_indicators(
+        agg_kind=AggKind.DAY, start_ts=2, stop_ts=3, session=dbsession
+    )
+    assert value == SHARED_FILES_VALUE_AS_OBJECT_1
+    assert SharedFilesValue.model_dump(value) == SHARED_FILES_VALUE_AS_DICT_1
+
+    value = kpi.compute_value_from_indicators(
+        agg_kind=AggKind.DAY, start_ts=1, stop_ts=3, session=dbsession
+    )
+    assert value == SHARED_FILES_VALUE_AS_OBJECT_2
+
+    value = kpi.compute_value_from_indicators(
+        agg_kind=AggKind.DAY, start_ts=1, stop_ts=1, session=dbsession
+    )
+    assert value == SHARED_FILES_VALUE_AS_OBJECT_3

--- a/backend/tests/unit/business/processing_nok.txt
+++ b/backend/tests/unit/business/processing_nok.txt
@@ -7,10 +7,12 @@
 {"level":"info","msg":"handled request","request":{}}
 {"level":"info","msg":"handled request","request":{"host":"mathews.localhost:8000"}}
 {"level":"info","msg":"handled request","request":{"uri":"/page2.html"}}
-{"level":"info","msg":"handled request","request":{"host":"mathews.localhost:8000","uri":"/page2.html"}}
-{"level":"info","msg":"handled request","request":{"host":"nomad.renaud.test","uri":"/page2.html"}}
-{"level":"info","msg":"handled request","request":{"host":"kiwix.renaud.test","uri":"/something.html"}}
-{"level":"info","msg":"handled request","request":{"host":"kiwix.renaud.test","uri":"/content/unknown_zim/questions/149/1-5-million-lines-of-code-0-tests-where-should-we-start"}}
-{"level":"info","msg":"handled request","request":{"host":"kiwix.renaud.test","uri":"/content/wikipedia_en_all/questions/149/1-5-million-lines-of-code-0-tests-where-should-we-start"}}
-{"level":"info","msg":"handled request","request":{"host":"kiwix.renaud.test","uri":"/content/wikipedia_en_all/assets/image.png"},"resp_headers":{"Content-Type":["image/png"]}}
+{"level":"info","msg":"handled request","request":{"host":"mathews.localhost:8000","uri":"/page2.html","method":"GET"},"status":200}
+{"level":"info","msg":"handled request","request":{"host":"nomad.renaud.test","uri":"/"}}
+{"level":"info","msg":"handled request","request":{"host":"nomad.renaud.test","uri":"/","method":"GET"}}
+{"level":"info","msg":"handled request","request":{"host":"nomad.renaud.test","uri":"/page2.html","method":"GET"},"status":200}
+{"level":"info","msg":"handled request","request":{"host":"kiwix.renaud.test","uri":"/something.html","method":"GET"},"status":200}
+{"level":"info","msg":"handled request","request":{"host":"kiwix.renaud.test","uri":"/content/unknown_zim/questions/149/1-5-million-lines-of-code-0-tests-where-should-we-start","method":"GET"},"status":200}
+{"level":"info","msg":"handled request","request":{"host":"kiwix.renaud.test","uri":"/content/wikipedia_en_all/questions/149/1-5-million-lines-of-code-0-tests-where-should-we-start","method":"GET"},"status":200}
+{"level":"info","msg":"handled request","request":{"host":"kiwix.renaud.test","uri":"/content/wikipedia_en_all/assets/image.png","method":"GET"},"resp_headers":{"Content-Type":["image/png"]},"status":200}
 {"@timestamp":"2023-07-04T08:36:34.383Z","@metadata":{"beat":"filebeat","type":"_doc","version":"8.8.1"},"message":"{"level":"info","ts":1688459792.8632474,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"172.18.0.1","remote_port":"40236","proto":"HTTP/1.1","method":"GET","host":"mathews.localhost:8000","uri":"/page2.html","headers":{"Sec-Fetch-Site":["same-origin"],"Accept":["text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"],"Accept-Language":["en-US,en;q=0.5"],"Accept-Encoding":["gzip, deflate, br"],"Connection":["keep-alive"],"Referer":["http://mathews.localhost:8000/"],"User-Agent":["Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/114.0"],"Upgrade-Insecure-Requests":["1"],"Sec-Fetch-Dest":["document"],"Sec-Fetch-Mode":["navigate"],"Sec-Fetch-User":["?1"]}},"user_id":"","duration":0.00134691,"size":124,"status":200,"resp_headers":{"Content-Type":["text/html; charset=utf-8"],"Last-Modified":["Thu, 29 Jun 2023 08:12:31 GMT"],"Accept-Ranges":["bytes"],"Content-Length":["124"],"Server":["Caddy"],"Etag":["\\"rx09gv3g\\""]}}","input":{"type":"filestream"},"ecs":{"version":"8.0.0"},"host":{"name":"543ac1bf4520"},"agent":{"type":"filebeat","version":"8.8.1","ephemeral_id":"365f8d01-4854-499c-aa27-b6a24a0758f6","id":"45854e6a-b7a3-46ca-858a-36c53cfaf4ab","name":"543ac1bf4520"},"log":{"offset":34351,"file":{"path":"/reverse-proxy-logs/caddy_access_logs.json"}}}

--- a/backend/tests/unit/business/test_log_converter.py
+++ b/backend/tests/unit/business/test_log_converter.py
@@ -11,6 +11,10 @@ from offspot_metrics_backend.business.inputs.content_visit import (
     ContentItemVisit,
 )
 from offspot_metrics_backend.business.inputs.input import Input
+from offspot_metrics_backend.business.inputs.shared_files import (
+    SharedFilesOperation,
+    SharedFilesOperationKind,
+)
 from offspot_metrics_backend.business.reverse_proxy_config import ReverseProxyConfig
 
 
@@ -18,13 +22,13 @@ from offspot_metrics_backend.business.reverse_proxy_config import ReverseProxyCo
     "log_line, expected_inputs",
     [
         (
-            r"""{"level":"info","msg":"handled request","""
-            r""""request":{"host":"nomad.renaud.test","uri":"/"}}""",
+            r"""{"level":"info","msg":"handled request","status":"200","""
+            r""""request":{"host":"nomad.renaud.test","uri":"/","method":"GET"}}""",
             [ContentHomeVisit(content="Nomad exercices du CP à la 3è")],
         ),
         (
-            r"""{"level":"info","msg":"handled request","""
-            r""""request":{"host":"kiwix.renaud.test","""
+            r"""{"level":"info","msg":"handled request","status":"200","""
+            r""""request":{"host":"kiwix.renaud.test","method":"GET","""
             r""""uri":"/content/wikipedia_en_all/questions/149/"""
             r"""1-5-million-lines-of-code-0-tests-where"},"""
             r""""resp_headers":{"Content-Type":["text/html; charset=utf"]}}""",
@@ -36,10 +40,70 @@ from offspot_metrics_backend.business.reverse_proxy_config import ReverseProxyCo
             ],
         ),
         (
-            r"""{"level":"info","msg":"handled request","""
-            r""""request":{"host":"kiwix.renaud.test","""
+            r"""{"level":"info","msg":"handled request","status":"200","""
+            r""""request":{"host":"kiwix.renaud.test","method":"GET","""
             r""""uri":"/content/wikipedia_en_all/"}}""",
             [ContentHomeVisit(content="Wikipedia")],
+        ),
+        (
+            r"""{"level":"info","msg":"handled request","status":"201","""
+            r""""request":{"host":"edupi1.renaud.test","method":"POST","""
+            r""""uri":"/api/documents/"}}""",
+            [SharedFilesOperation(kind=SharedFilesOperationKind.FILE_CREATED)],
+        ),
+        (
+            r"""{"level":"info","msg":"handled request","status":"204","""
+            r""""request":{"host":"edupi2.renaud.test","method":"DELETE","""
+            r""""uri":"/api/documents/123"}}""",
+            [SharedFilesOperation(kind=SharedFilesOperationKind.FILE_DELETED)],
+        ),
+        (
+            r"""{"level":"info","msg":"handled request","status":"400","""
+            r""""request":{"host":"edupi1.renaud.test","method":"POST","""
+            r""""uri":"/api/documents/"}}""",
+            [],
+        ),
+        (
+            r"""{"level":"info","msg":"handled request","status":"400","""
+            r""""request":{"host":"edupi2.renaud.test","method":"DELETE","""
+            r""""uri":"/api/documents/123"}}""",
+            [],
+        ),
+        (
+            r"""{"level":"info","msg":"handled request","status":"201","""
+            r""""request":{"host":"edupi1.renaud.test","method":"GET","""
+            r""""uri":"/api/documents/"}}""",
+            [],
+        ),
+        (
+            r"""{"level":"info","msg":"handled request","status":"204","""
+            r""""request":{"host":"edupi2.renaud.test","method":"GET","""
+            r""""uri":"/api/documents/123"}}""",
+            [],
+        ),
+        (
+            r"""{"level":"info","msg":"handled request","status":"201","""
+            r""""request":{"host":"edupi1.renaud.test","method":"POST","""
+            r""""uri":"/api/documents/1"}}""",
+            [],
+        ),
+        (
+            r"""{"level":"info","msg":"handled request","status":"204","""
+            r""""request":{"host":"edupi2.renaud.test","method":"DELETE","""
+            r""""uri":"/api/documents/"}}""",
+            [],
+        ),
+        (
+            r"""{"level":"info","msg":"handled request","status":"201","""
+            r""""request":{"host":"imnotedupi.renaud.test","method":"POST","""
+            r""""uri":"/api/documents/"}}""",
+            [],
+        ),
+        (
+            r"""{"level":"info","msg":"handled request","status":"204","""
+            r""""request":{"host":"imnotedupi.renaud.test","method":"DELETE","""
+            r""""uri":"/api/documents/123"}}""",
+            [],
         ),
     ],
 )

--- a/backend/tests/unit/business/test_packages_config.py
+++ b/backend/tests/unit/business/test_packages_config.py
@@ -42,6 +42,7 @@ def test_parsing_ok(reverse_proxy_config: Callable[[str | None], ReverseProxyCon
         "wikipedia_en_all": {"title": "Wikipedia"},
     }
     assert config.zim_host == "kiwix.renaud.test"
+    assert config.edupi_hosts == ["edupi1.renaud.test", "edupi2.renaud.test"]
 
 
 def test_parsing_warnings(
@@ -53,12 +54,14 @@ def test_parsing_warnings(
         "Package with missing 'title' ignored",
         "Unsupported URL: tata",
         "Package with missing 'kind' ignored",
-        "Ignoring second zim host 'kiwix.renaud.test', only one host supported",
+        "Ignoring second zim host 'kaka.renaud.test', only one host supported",
         "Unsupported ZIM URL: //kiwix.renaud.test/kkkk#toto",
         "Package with unsupported 'kind' : 'ooo' ignored",
+        "Ignoring unknown app ident 'wikifundi-en.offspot.kiwix.org'",
     ]
     assert config.files == {}
     assert config.zims == {
         "wikipedia_en_all": {"title": "Wikipedia"},
     }
     assert config.zim_host == "kiwix.renaud.test"
+    assert config.edupi_hosts == ["edupi.renaud.test", "edupi2.renaud.test"]

--- a/backend/tests/unit/conf_files/conf_ok.yaml
+++ b/backend/tests/unit/conf_files/conf_ok.yaml
@@ -55,3 +55,11 @@ packages:
   tags:
   - android
   url: //mathews.renaud.test/
+- kind: app
+  ident: edupi.offspot.kiwix.org
+  title: Shared files 1
+  url: //edupi1.renaud.test/
+- kind: app
+  ident: edupi.offspot.kiwix.org
+  title: Shared files 2
+  url: //edupi2.renaud.test/

--- a/backend/tests/unit/conf_files/conf_with_warnings.yaml
+++ b/backend/tests/unit/conf_files/conf_with_warnings.yaml
@@ -21,7 +21,7 @@ packages:
 - url: //kiwix.renaud.test/viewer#wikipedia_en_all
   title: toto
 
-# second host ignored
+# second ZIM host ignored
 - kind: zim
   url: //kaka.renaud.test/viewer#toto
   title: toto
@@ -35,3 +35,21 @@ packages:
 - kind: ooo
   url: //kiwix.renaud.test/ssss
   title: toto
+
+# One edupi ok
+- kind: app
+  ident: edupi.offspot.kiwix.org
+  title: Shared files
+  url: //edupi.renaud.test/
+
+# Second edupi ok
+- kind: app
+  ident: edupi.offspot.kiwix.org
+  title: Shared files 2
+  url: //edupi2.renaud.test/
+
+# Unknown app ident
+- kind: app
+  ident: wikifundi-en.offspot.kiwix.org
+  title: Wikifundi
+  url: //wikifundi.renaud.test/

--- a/backend/tests/unit/routes/conftest.py
+++ b/backend/tests/unit/routes/conftest.py
@@ -18,6 +18,10 @@ from offspot_metrics_backend.business.kpis.content_popularity import (
     ContentPopularityItem,
     ContentPopularityValue,
 )
+from offspot_metrics_backend.business.kpis.shared_files import (
+    SharedFiles,
+    SharedFilesValue,
+)
 from offspot_metrics_backend.business.reverse_proxy_config import ReverseProxyConfig
 from offspot_metrics_backend.db.models import KpiRecord
 from offspot_metrics_backend.main import Main
@@ -75,6 +79,12 @@ async def kpis(dbsession: Session) -> AsyncGenerator[list[KpiRecord], Any]:
             agg_kind="W",
             agg_value="2023 W10",
             kpi_value=DummyKpiValue.model_validate("199"),
+        ),
+        KpiRecord(
+            kpi_id=SharedFiles.unique_id,
+            agg_kind="W",
+            agg_value="2023 W10",
+            kpi_value=SharedFilesValue(files_created=65, files_deleted=45),
         ),
     ]
     for kpi in kpis:

--- a/backend/tests/unit/routes/test_kpis_endpoints.py
+++ b/backend/tests/unit/routes/test_kpis_endpoints.py
@@ -30,6 +30,12 @@ from offspot_metrics_backend.main import PREFIX
                 }
             ],
         ),
+        (
+            2005,
+            "W",
+            "2023 W10",
+            {"files_created": 65, "files_deleted": 45},
+        ),
         (-2001, "W", "2023 W10", "199"),
     ],
 )

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -68,6 +68,17 @@ services:
       - reverse-proxy-srv:/srv
     ports:
       - 127.0.0.1:8000:80
+  edupi:
+    container_name: om_edupi
+    image: ghcr.io/offspot/edupi:dev
+    ports:
+      - 127.0.0.1:8004:80
+    volumes:
+      - edupi-data:/data
+    environment:
+      ADMIN_USERNAME: admin
+      ADMIN_PASSWORD: admin
 volumes:
   reverse-proxy-srv:
   logwatcher-data:
+  edupi-data:

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - --reload-dir
       - /usr/local/lib/python3.11/site-packages/offspot_metrics_backend
     ports:
-      - 8002:80
+      - 127.0.0.1:8002:80
     environment:
       PACKAGE_CONF_FILE: /conf/packages.yml
       PROCESSING_DISABLED: "True"
@@ -33,6 +33,7 @@ services:
       - ../backend/pyproject.toml:/src/pyproject.toml
       - ../backend/htmlcov:/src/htmlcov
       - ../backend/tasks.py:/src/tasks.py
+      - ../backend/dev_tools:/src/dev_tools
       - ../backend/tests:/src/tests
     environment:
       PROCESSING_DISABLED: "True"
@@ -46,7 +47,7 @@ services:
     volumes:
       - ../frontend:/work
     ports:
-      - 8003:5173
+      - 127.0.0.1:8003:5173
   kiwix-serve:
     container_name: om_kiwix
     image: ghcr.io/offspot/kiwix-serve:3.5.0-2 # there is no more latest/dev version
@@ -57,7 +58,7 @@ services:
       - /data/devops.stackexchange.com_en_all_2023-05.zim
       - /data/sqa.stackexchange.com_en_all_2023-05.zim
     ports:
-      - 8001:80
+      - 127.0.0.1:8001:80
   reverse-proxy:
     container_name: om_reverse-proxy
     image: caddy:2.6.1-alpine
@@ -66,7 +67,7 @@ services:
       - ./file-browser-data:/file-browser-data
       - reverse-proxy-srv:/srv
     ports:
-      - 8000:80
+      - 127.0.0.1:8000:80
 volumes:
   reverse-proxy-srv:
   logwatcher-data:

--- a/dev/packages.yml
+++ b/dev/packages.yml
@@ -8,8 +8,8 @@ packages:
   title: StackExchange - Software Quality Assurance and Testing
   url: //kiwix.localhost:8000/viewer/viewer#sqa.stackexchange.com_en_all_2023-05
 - kind: files
-  title: "Nomad exercices du CP \xE0 la 3\xE8"
+  title: Nomad exercices du CP \xE0 la 3\xE8
   url: //nomad.localhost:8000/
 - kind: files
-  title: "Chasse au tr\xE9sor Math Mathews"
+  title: Chasse au tr\xE9sor Math Mathews
   url: //mathews.localhost:8000/

--- a/dev/packages.yml
+++ b/dev/packages.yml
@@ -13,3 +13,7 @@ packages:
 - kind: files
   title: Chasse au tr\xE9sor Math Mathews
   url: //mathews.localhost:8000/
+- kind: app
+  title: Shared files
+  url: //edupi.localhost:8000/
+  ident: edupi.offspot.kiwix.org

--- a/dev/reverse-proxy/config/Caddyfile
+++ b/dev/reverse-proxy/config/Caddyfile
@@ -28,3 +28,7 @@ nomad.localhost:80 {
 kiwix.localhost:80 {
     reverse_proxy om_kiwix:80
 }
+
+edupi.localhost:80 {
+    reverse_proxy om_edupi:80
+}


### PR DESCRIPTION
## Rationale

Fix #27
+ small fixes

## Changes
- new KPI `SharedFiles`
- new Indicator `SharedFilesOperations`
- new Input `SharedFilesOperation`
- new log processing logic to create `SharedFilesOperation` input sfrom edupi logs in Caddy reverse proxy
- bind Docker containers port only on localhost in dev docker-compose
- fix wrong second ZIM host reported in warning
- fix incorrect quotes in `packages.conf`
