### PR TITLE
Parse timestamp in reverse proxy logs + make log conversion logic more generic / modular

### DIFF
--- a/backend/src/offspot_metrics_backend/business/caddy_log_converter.py
+++ b/backend/src/offspot_metrics_backend/business/caddy_log_converter.py
@@ -69,6 +69,7 @@ class CaddyLogConverter:
 
         try:
             log = CaddyLog.model_validate_json(line)
+            del line
         except ValidationError:
             return ProcessingResult(inputs=[], warning="JSON parsing failed")
 

--- a/backend/src/offspot_metrics_backend/business/input_generator.py
+++ b/backend/src/offspot_metrics_backend/business/input_generator.py
@@ -40,19 +40,21 @@ class ZimInputGenerator(InputGenerator):
     zim_name: str
     title: str
 
+    zim_re = re.compile(r"^/content/(?P<zim_name>.+?)(?P<zim_path>/.*)?$")
+
     def process(self, log: LogData) -> list[Input]:
         """Process a given log line and generate corresponding inputs"""
-        match = re.match(r"^/content/(?P<zim>.+?)(?P<item>/.*)?$", log.uri)
+        match = self.zim_re.match(log.uri)
         if not match:
             return []
 
-        zim = match.group("zim")
-        item = match.group("item")
+        zim_name = match.group("zim_name")
+        zim_path = match.group("zim_path")
 
-        if zim != self.zim_name:
+        if zim_name != self.zim_name:
             return []
 
-        if item is None or item == "/":
+        if zim_path is None or zim_path == "/":
             return [ContentHomeVisit(content=self.title)]
         else:
             if log.content_type is None:
@@ -63,7 +65,7 @@ class ZimInputGenerator(InputGenerator):
                 or "epub" in log.content_type
                 or "pdf" in log.content_type
             ):
-                return [ContentItemVisit(content=self.title, item=item)]
+                return [ContentItemVisit(content=self.title, item=zim_path)]
             else:
                 return []
 

--- a/backend/src/offspot_metrics_backend/business/input_generator.py
+++ b/backend/src/offspot_metrics_backend/business/input_generator.py
@@ -1,0 +1,105 @@
+import abc
+import re
+from http import HTTPStatus
+
+from pydantic.dataclasses import dataclass
+
+from offspot_metrics_backend.business.inputs.content_visit import (
+    ContentHomeVisit,
+    ContentItemVisit,
+)
+from offspot_metrics_backend.business.inputs.input import Input
+from offspot_metrics_backend.business.inputs.shared_files import (
+    SharedFilesOperation,
+    SharedFilesOperationKind,
+)
+from offspot_metrics_backend.business.log_data import LogData
+
+
+@dataclass
+class InputGenerator(abc.ABC):
+    """A generic input generator interface
+
+    An input generator is responsible to process a log line and
+    generate corresponding inputs. It is associated with a hostname used
+    on the Pi (i.e. if we have two hosts, we have two generators, one per host)
+    """
+
+    host: str
+
+    @abc.abstractmethod
+    def process(self, log: LogData) -> list[Input]:
+        """Process a given log line and generate corresponding inputs"""
+        ...  # pragma: no cover
+
+
+@dataclass
+class ZimInputGenerator(InputGenerator):
+    """A generator for zim packages"""
+
+    zim_name: str
+    title: str
+
+    def process(self, log: LogData) -> list[Input]:
+        """Process a given log line and generate corresponding inputs"""
+        match = re.match(r"^/content/(?P<zim>.+?)(?P<item>/.*)?$", log.uri)
+        if not match:
+            return []
+
+        zim = match.group("zim")
+        item = match.group("item")
+
+        if zim != self.zim_name:
+            return []
+
+        if item is None or item == "/":
+            return [ContentHomeVisit(content=self.title)]
+        else:
+            if log.content_type is None:
+                return []
+
+            if (
+                "html" in log.content_type
+                or "epub" in log.content_type
+                or "pdf" in log.content_type
+            ):
+                return [ContentItemVisit(content=self.title, item=item)]
+            else:
+                return []
+
+
+@dataclass
+class EdupiInputGenerator(InputGenerator):
+    """A specific generator for edupi package"""
+
+    def process(self, log: LogData) -> list[Input]:
+        """Transform one log event identified as edupi into inputs"""
+        if (
+            log.method == "POST"
+            and log.status == HTTPStatus.CREATED
+            and log.uri == "/api/documents/"
+        ):
+            return [SharedFilesOperation(kind=SharedFilesOperationKind.FILE_CREATED)]
+        elif (
+            log.method == "DELETE"
+            and log.status == HTTPStatus.NO_CONTENT
+            and log.uri.startswith("/api/documents/")
+            and len(log.uri) > len("/api/documents/")
+        ):
+            return [SharedFilesOperation(kind=SharedFilesOperationKind.FILE_DELETED)]
+        else:
+            return []
+
+
+@dataclass
+class FilesInputGenerator(InputGenerator):
+    """A generator for file packages"""
+
+    title: str
+
+    def process(self, log: LogData) -> list[Input]:
+        """Process a given log line and generate corresponding inputs"""
+        if log.uri == "/":
+            return [ContentHomeVisit(content=self.title)]
+        else:
+            return []

--- a/backend/src/offspot_metrics_backend/business/inputs/clock_tick.py
+++ b/backend/src/offspot_metrics_backend/business/inputs/clock_tick.py
@@ -1,12 +1,8 @@
-import datetime
 from dataclasses import dataclass
 
-from offspot_metrics_backend.business.inputs.input import Input
+from offspot_metrics_backend.business.inputs.input import InputWithTime
 
 
 @dataclass
-class ClockTick(Input):
+class ClockTick(InputWithTime):
     """Input representing a clock tick ; there is one tick per minute"""
-
-    # moment where the tick occured
-    now: datetime.datetime

--- a/backend/src/offspot_metrics_backend/business/inputs/clock_tick.py
+++ b/backend/src/offspot_metrics_backend/business/inputs/clock_tick.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 
-from offspot_metrics_backend.business.inputs.input import InputWithTime
+from offspot_metrics_backend.business.inputs.input import TimedInput
 
 
 @dataclass
-class ClockTick(InputWithTime):
+class ClockTick(TimedInput):
     """Input representing a clock tick ; there is one tick per minute"""

--- a/backend/src/offspot_metrics_backend/business/inputs/input.py
+++ b/backend/src/offspot_metrics_backend/business/inputs/input.py
@@ -9,7 +9,7 @@ class Input:
 
 
 @dataclass
-class InputWithTime(Input):
+class TimedInput(Input):
     """Input with information about when it happened"""
 
     # moment where the input occured

--- a/backend/src/offspot_metrics_backend/business/inputs/input.py
+++ b/backend/src/offspot_metrics_backend/business/inputs/input.py
@@ -1,4 +1,16 @@
+import datetime
+from dataclasses import dataclass
+
+
 class Input:
     """A generic input interface"""
 
     ...
+
+
+@dataclass
+class InputWithTime(Input):
+    """Input with information about when it happened"""
+
+    # moment where the input occured
+    ts: datetime.datetime

--- a/backend/src/offspot_metrics_backend/business/log_data.py
+++ b/backend/src/offspot_metrics_backend/business/log_data.py
@@ -1,0 +1,17 @@
+import datetime
+
+from pydantic.dataclasses import dataclass
+
+
+@dataclass
+class LogData:
+    """Generic log dataclass holding data found in a log line
+
+    This is typically generated from a reverse proxy, but is meant to make
+    this independant of the reverse proxy really used"""
+
+    content_type: str | None
+    status: int
+    uri: str
+    method: str
+    ts: datetime.datetime

--- a/backend/src/offspot_metrics_backend/business/reverse_proxy_config.py
+++ b/backend/src/offspot_metrics_backend/business/reverse_proxy_config.py
@@ -46,6 +46,10 @@ class FileConfig(Config):
 class ReverseProxyConfig:
     """Holds the reverse proxy config, extracted from PACKAGE_CONF_FILE"""
 
+    host_re = re.compile(r"^//(?P<host>.*?)/.*")
+    viewer_re = re.compile(r"^//.*?/viewer#(?P<zim_name>.*)$")
+    content_re = re.compile(r"^//.*?/content/(?P<zim_name>.+?)(?:/.*)?$")
+
     def __init__(self) -> None:
         self.files: list[FileConfig] = []
         self.apps: list[AppConfig] = []
@@ -109,7 +113,7 @@ class ReverseProxyConfig:
             self.warnings.append("Package with missing 'title' ignored")
             return
 
-        match = re.match(r"^//(?P<host>.*?)/.*", url)
+        match = self.host_re.match(url)
         if not match:
             self.warnings.append(f"Unsupported URL: {url}")
             return
@@ -124,8 +128,8 @@ class ReverseProxyConfig:
             self.files.append(FileConfig(title=title, host=host))
             return
         elif kind == "zim":
-            match_viewer = re.match(r"^//.*?/viewer#(?P<zim_name>.*)$", url)
-            match_content = re.match(r"^//.*?/content/(?P<zim_name>.+?)(?:/.*)?$", url)
+            match_viewer = self.viewer_re.match(url)
+            match_content = self.content_re.match(url)
             if match_viewer:
                 zim_name = match_viewer.group("zim_name")
             elif match_content:

--- a/backend/src/offspot_metrics_backend/main.py
+++ b/backend/src/offspot_metrics_backend/main.py
@@ -86,7 +86,7 @@ class Main:
             await sleep(TICK_PERIOD)
             logger.debug("Processing a clock tick")
             now_period, now_datetime = Period.now()
-            self.processor.process_input(ClockTick(now=now_datetime))
+            self.processor.process_input(ClockTick(ts=now_datetime))
             self.processor.process_tick(tick_period=now_period)
 
     def handle_log_event(self, event: NewLineEvent):

--- a/backend/src/offspot_metrics_backend/main.py
+++ b/backend/src/offspot_metrics_backend/main.py
@@ -91,8 +91,8 @@ class Main:
 
     def handle_log_event(self, event: NewLineEvent):
         logger.debug(f"Log watcher sent: {event.line_content}")
-        inputs = self.converter.process(event.line_content)
-        for input_ in inputs:
+        result = self.converter.process(event.line_content)
+        for input_ in result.inputs:
             logger.debug(f"Processing input: {input_}")
             self.processor.process_input(input_=input_)
 

--- a/backend/tests/unit/business/processing_nok.txt
+++ b/backend/tests/unit/business/processing_nok.txt
@@ -2,21 +2,22 @@
 {}
 {"level":"warn"}
 {"level":"info"}
-{"level":"info","msg":"something"}
-{"level":"info","msg":"handled request"}
-{"level":"info","msg":"handled request","request":{}}
-{"level":"info","msg":"handled request","request":{"host":"mathews.localhost:8000"}}
-{"level":"info","msg":"handled request","request":{"uri":"/page2.html"}}
-{"level":"info","msg":"handled request","request":{"host":"mathews.localhost:8000","uri":"/page2.html","method":"GET"},"status":200}
-{"level":"info","msg":"handled request","request":{"host":"nomad.renaud.test","uri":"/"}}
-{"level":"info","msg":"handled request","request":{"host":"nomad.renaud.test","uri":"/","method":"GET"}}
-{"level":"info","msg":"handled request","request":{"host":"nomad.renaud.test","uri":"/","method":"GET"},"status":200}
-{"level":"info","msg":"handled request","request":{"host":"nomad.renaud.test","uri":"/page2.html","method":"GET"},"status":200, "resp_headers": {}}
-{"level":"info","msg":"something else","request":{"host":"nomad.renaud.test","uri":"/","method":"GET"},"status":200, "resp_headers": {}}
-{"level":"error","msg":"handled request","request":{"host":"nomad.renaud.test","uri":"/","method":"GET"},"status":200, "resp_headers": {}}
-{"level":"info","msg":"handled request","request":{"host":"kiwix.renaud.test","uri":"/something.html","method":"GET"},"status":200, "resp_headers": {}}
-{"level":"info","msg":"handled request","request":{"host":"unknown.renaud.test","uri":"/","method":"GET"},"status":200, "resp_headers": {}}
-{"level":"info","msg":"handled request","request":{"host":"kiwix.renaud.test","uri":"/content/unknown_zim/questions/149/1-5-million-lines-of-code-0-tests-where-should-we-start","method":"GET"},"status":200, "resp_headers": {}}
-{"level":"info","msg":"handled request","request":{"host":"kiwix.renaud.test","uri":"/content/wikipedia_en_all/questions/149/1-5-million-lines-of-code-0-tests-where-should-we-start","method":"GET"},"status":200, "resp_headers": {}}
-{"level":"info","msg":"handled request","request":{"host":"kiwix.renaud.test","uri":"/content/wikipedia_en_all/assets/image.png","method":"GET"},"resp_headers":{"Content-Type":["image/png"]},"status":200}
+{"level":"info","ts":1688459792.8632474}
+{"level":"info","msg":"something"},"ts":1688459792.8632474}
+{"level":"info","msg":"handled request"},"ts":1688459792.8632474}
+{"level":"info","msg":"handled request","request":{}},"ts":1688459792.8632474}
+{"level":"info","msg":"handled request","request":{"host":"mathews.localhost:8000"}},"ts":1688459792.8632474}
+{"level":"info","msg":"handled request","request":{"uri":"/"}},"ts":1688459792.8632474}
+{"level":"info","msg":"handled request","request":{"host":"mathews.localhost:8000","uri":"/page2.html","method":"GET"},"status":200,"ts":1688459792.8632474}
+{"level":"info","msg":"handled request","request":{"host":"nomad.renaud.test","uri":"/"}},"ts":1688459792.8632474}
+{"level":"info","msg":"handled request","request":{"host":"nomad.renaud.test","uri":"/","method":"GET"}},"ts":1688459792.8632474}
+{"level":"info","msg":"handled request","request":{"host":"nomad.renaud.test","uri":"/","method":"GET"},"status":200},"ts":1688459792.8632474}
+{"level":"info","msg":"handled request","request":{"host":"nomad.renaud.test","uri":"/page2.html","method":"GET"},"status":200, "resp_headers": {},"ts":1688459792.8632474}
+{"level":"info","msg":"something else","request":{"host":"nomad.renaud.test","uri":"/","method":"GET"},"status":200, "resp_headers": {},"ts":1688459792.8632474}
+{"level":"error","msg":"handled request","request":{"host":"nomad.renaud.test","uri":"/","method":"GET"},"status":200, "resp_headers": {},"ts":1688459792.8632474}
+{"level":"info","msg":"handled request","request":{"host":"kiwix.renaud.test","uri":"/something.html","method":"GET"},"status":200, "resp_headers": {},"ts":1688459792.8632474}
+{"level":"info","msg":"handled request","request":{"host":"unknown.renaud.test","uri":"/","method":"GET"},"status":200, "resp_headers": {},"ts":1688459792.8632474}
+{"level":"info","msg":"handled request","request":{"host":"kiwix.renaud.test","uri":"/content/unknown_zim/questions/149/1-5-million-lines-of-code-0-tests-where-should-we-start","method":"GET"},"status":200, "resp_headers": {},"ts":1688459792.8632474}
+{"level":"info","msg":"handled request","request":{"host":"kiwix.renaud.test","uri":"/content/wikipedia_en_all/questions/149/1-5-million-lines-of-code-0-tests-where-should-we-start","method":"GET"},"status":200, "resp_headers": {},"ts":1688459792.8632474}
+{"level":"info","msg":"handled request","request":{"host":"kiwix.renaud.test","uri":"/content/wikipedia_en_all/assets/image.png","method":"GET"},"resp_headers":{"Content-Type":["image/png"]},"status":200,"ts":1688459792.8632474}
 {"@timestamp":"2023-07-04T08:36:34.383Z","@metadata":{"beat":"filebeat","type":"_doc","version":"8.8.1"},"message":"{"level":"info","ts":1688459792.8632474,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"172.18.0.1","remote_port":"40236","proto":"HTTP/1.1","method":"GET","host":"mathews.localhost:8000","uri":"/page2.html","headers":{"Sec-Fetch-Site":["same-origin"],"Accept":["text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"],"Accept-Language":["en-US,en;q=0.5"],"Accept-Encoding":["gzip, deflate, br"],"Connection":["keep-alive"],"Referer":["http://mathews.localhost:8000/"],"User-Agent":["Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/114.0"],"Upgrade-Insecure-Requests":["1"],"Sec-Fetch-Dest":["document"],"Sec-Fetch-Mode":["navigate"],"Sec-Fetch-User":["?1"]}},"user_id":"","duration":0.00134691,"size":124,"status":200,"resp_headers":{"Content-Type":["text/html; charset=utf-8"],"Last-Modified":["Thu, 29 Jun 2023 08:12:31 GMT"],"Accept-Ranges":["bytes"],"Content-Length":["124"],"Server":["Caddy"],"Etag":["\\"rx09gv3g\\""]}}","input":{"type":"filestream"},"ecs":{"version":"8.0.0"},"host":{"name":"543ac1bf4520"},"agent":{"type":"filebeat","version":"8.8.1","ephemeral_id":"365f8d01-4854-499c-aa27-b6a24a0758f6","id":"45854e6a-b7a3-46ca-858a-36c53cfaf4ab","name":"543ac1bf4520"},"log":{"offset":34351,"file":{"path":"/reverse-proxy-logs/caddy_access_logs.json"}}}

--- a/backend/tests/unit/business/test_log_converter.py
+++ b/backend/tests/unit/business/test_log_converter.py
@@ -73,56 +73,56 @@ from offspot_metrics_backend.business.reverse_proxy_config import ReverseProxyCo
         (
             r"""{"level":"info","msg":"handled request","status":"400","""
             r""""request":{"host":"edupi1.renaud.test","method":"POST","""
-            r""""uri":"/api/documents/"},resp_headers={},"""
+            r""""uri":"/api/documents/"},"resp_headers":{},"""
             r""""ts":1688459792.8632474}""",
             [],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"400","""
             r""""request":{"host":"edupi2.renaud.test","method":"DELETE","""
-            r""""uri":"/api/documents/123"},resp_headers={},"""
+            r""""uri":"/api/documents/123"},"resp_headers":{},"""
             r""""ts":1688459792.8632474}""",
             [],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"201","""
             r""""request":{"host":"edupi1.renaud.test","method":"GET","""
-            r""""uri":"/api/documents/"},resp_headers={},"""
+            r""""uri":"/api/documents/"},"resp_headers":{},"""
             r""""ts":1688459792.8632474}""",
             [],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"204","""
             r""""request":{"host":"edupi2.renaud.test","method":"GET","""
-            r""""uri":"/api/documents/123"},resp_headers={},"""
+            r""""uri":"/api/documents/123"},"resp_headers":{},"""
             r""""ts":1688459792.8632474}""",
             [],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"201","""
             r""""request":{"host":"edupi1.renaud.test","method":"POST","""
-            r""""uri":"/api/documents/1"},resp_headers={},"""
+            r""""uri":"/api/documents/1"},"resp_headers":{},"""
             r""""ts":1688459792.8632474}""",
             [],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"204","""
             r""""request":{"host":"edupi2.renaud.test","method":"DELETE","""
-            r""""uri":"/api/documents/"},resp_headers={},"""
+            r""""uri":"/api/documents/"},"resp_headers":{},"""
             r""""ts":1688459792.8632474}""",
             [],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"201","""
             r""""request":{"host":"imnotedupi.renaud.test","method":"POST","""
-            r""""uri":"/api/documents/"},resp_headers={},"""
+            r""""uri":"/api/documents/"},"resp_headers":{},"""
             r""""ts":1688459792.8632474}""",
             [],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"204","""
             r""""request":{"host":"imnotedupi.renaud.test","method":"DELETE","""
-            r""""uri":"/api/documents/123"},resp_headers={},"""
+            r""""uri":"/api/documents/123"},"resp_headers":{},"""
             r""""ts":1688459792.8632474}""",
             [],
         ),
@@ -134,8 +134,9 @@ def test_process_ok(
     reverse_proxy_config: Callable[[str], ReverseProxyConfig],
 ):
     converter = CaddyLogConverter(reverse_proxy_config("conf_ok.yaml"))
-    inputs = converter.process(log_line)
-    assert inputs == expected_inputs
+    result = converter.process(log_line)
+    assert result.warning is None
+    assert result.inputs == expected_inputs
 
 
 def test_process_nok(reverse_proxy_config: Callable[[str], ReverseProxyConfig]):
@@ -143,8 +144,8 @@ def test_process_nok(reverse_proxy_config: Callable[[str], ReverseProxyConfig]):
     path = pathlib.Path(__file__).parent.absolute().joinpath("processing_nok.txt")
     with open(path) as fp:
         for line in fp:
-            inputs = converter.process(line)
-            assert len(inputs) == 0, (
+            result = converter.process(line)
+            assert len(result.inputs) == 0, (
                 "Problem with this message which returned an input instead of none:"
                 f" {line}"
             )

--- a/backend/tests/unit/business/test_log_converter.py
+++ b/backend/tests/unit/business/test_log_converter.py
@@ -25,7 +25,7 @@ from offspot_metrics_backend.business.reverse_proxy_config import ReverseProxyCo
         (
             r"""{"level":"info","msg":"handled request","status":"200","""
             r""""request":{"host":"nomad.renaud.test","uri":"/","method":"GET"},"""
-            r""""resp_headers":{}}""",
+            r""""resp_headers":{},"ts":1688459792.8632474}""",
             [ContentHomeVisit(content="Nomad exercices du CP à la 3è")],
         ),
         (
@@ -33,7 +33,8 @@ from offspot_metrics_backend.business.reverse_proxy_config import ReverseProxyCo
             r""""request":{"host":"kiwix.renaud.test","method":"GET","""
             r""""uri":"/content/wikipedia_en_all/questions/149/"""
             r"""1-5-million-lines-of-code-0-tests-where"},"""
-            r""""resp_headers":{"Content-Type":["text/html; charset=utf"]}}""",
+            r""""resp_headers":{"Content-Type":["text/html; charset=utf"]},"""
+            r""""ts":1688459792.8632474}""",
             [
                 ContentItemVisit(
                     content="Wikipedia",
@@ -44,73 +45,85 @@ from offspot_metrics_backend.business.reverse_proxy_config import ReverseProxyCo
         (
             r"""{"level":"info","msg":"handled request","status":"200","""
             r""""request":{"host":"kiwix.renaud.test","method":"GET","""
-            r""""uri":"/content/wikipedia_en_all/"},"resp_headers":{}}""",
+            r""""uri":"/content/wikipedia_en_all/"},"resp_headers":{},"""
+            r""""ts":1688459792.8632474}""",
             [ContentHomeVisit(content="Wikipedia")],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"201","""
             r""""request":{"host":"edupi1.renaud.test","method":"POST","""
-            r""""uri":"/api/documents/"},"resp_headers":{}}""",
+            r""""uri":"/api/documents/"},"resp_headers":{},"""
+            r""""ts":1688459792.8632474}""",
             [SharedFilesOperation(kind=SharedFilesOperationKind.FILE_CREATED)],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"204","""
             r""""request":{"host":"edupi2.renaud.test","method":"DELETE","""
-            r""""uri":"/api/documents/123"},"resp_headers":{}}""",
+            r""""uri":"/api/documents/123"},"resp_headers":{},"""
+            r""""ts":1688459792.8632474}""",
             [SharedFilesOperation(kind=SharedFilesOperationKind.FILE_DELETED)],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"204","""
             r""""request":{"host":"edupi2.renaud.test","method":"GET","""
-            r""""uri":"/api/documents/123"},"resp_headers":{}}""",
+            r""""uri":"/api/documents/123"},"resp_headers":{},"""
+            r""""ts":1688459792.8632474}""",
             [],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"400","""
             r""""request":{"host":"edupi1.renaud.test","method":"POST","""
-            r""""uri":"/api/documents/"}},resp_headers={}""",
+            r""""uri":"/api/documents/"},resp_headers={},"""
+            r""""ts":1688459792.8632474}""",
             [],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"400","""
             r""""request":{"host":"edupi2.renaud.test","method":"DELETE","""
-            r""""uri":"/api/documents/123"}}""",
+            r""""uri":"/api/documents/123"},resp_headers={},"""
+            r""""ts":1688459792.8632474}""",
             [],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"201","""
             r""""request":{"host":"edupi1.renaud.test","method":"GET","""
-            r""""uri":"/api/documents/"}},resp_headers={}""",
+            r""""uri":"/api/documents/"},resp_headers={},"""
+            r""""ts":1688459792.8632474}""",
             [],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"204","""
             r""""request":{"host":"edupi2.renaud.test","method":"GET","""
-            r""""uri":"/api/documents/123"}},resp_headers={}""",
+            r""""uri":"/api/documents/123"},resp_headers={},"""
+            r""""ts":1688459792.8632474}""",
             [],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"201","""
             r""""request":{"host":"edupi1.renaud.test","method":"POST","""
-            r""""uri":"/api/documents/1"}},resp_headers={}""",
+            r""""uri":"/api/documents/1"},resp_headers={},"""
+            r""""ts":1688459792.8632474}""",
             [],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"204","""
             r""""request":{"host":"edupi2.renaud.test","method":"DELETE","""
-            r""""uri":"/api/documents/"}},resp_headers={}""",
+            r""""uri":"/api/documents/"},resp_headers={},"""
+            r""""ts":1688459792.8632474}""",
             [],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"201","""
             r""""request":{"host":"imnotedupi.renaud.test","method":"POST","""
-            r""""uri":"/api/documents/"}},resp_headers={}""",
+            r""""uri":"/api/documents/"},resp_headers={},"""
+            r""""ts":1688459792.8632474}""",
             [],
         ),
         (
             r"""{"level":"info","msg":"handled request","status":"204","""
             r""""request":{"host":"imnotedupi.renaud.test","method":"DELETE","""
-            r""""uri":"/api/documents/123"}},resp_headers={}""",
+            r""""uri":"/api/documents/123"},resp_headers={},"""
+            r""""ts":1688459792.8632474}""",
             [],
         ),
     ],

--- a/backend/tests/unit/business/test_packages_config.py
+++ b/backend/tests/unit/business/test_packages_config.py
@@ -3,8 +3,11 @@ from collections.abc import Callable
 import pytest
 
 from offspot_metrics_backend.business.reverse_proxy_config import (
+    AppConfig,
+    FileConfig,
     IncorrectConfigurationError,
     ReverseProxyConfig,
+    ZimConfig,
 )
 
 
@@ -32,17 +35,48 @@ def test_parsing_missing_packages(
 def test_parsing_ok(reverse_proxy_config: Callable[[str | None], ReverseProxyConfig]):
     config = reverse_proxy_config("conf_ok.yaml")
     assert config.warnings == []
-    assert config.files == {
-        "nomad.renaud.test": {"title": "Nomad exercices du CP à la 3è"},
-        "mathews.renaud.test": {"title": "Chasse au trésor Math Mathews"},
+    assert set(config.files) == {
+        FileConfig(
+            title="Nomad exercices du CP à la 3è",
+            host="nomad.renaud.test",
+        ),
+        FileConfig(
+            title="Chasse au trésor Math Mathews",
+            host="mathews.renaud.test",
+        ),
     }
-    assert config.zims == {
-        "super.zim_2023-05": {"title": "Super content"},
-        "wikipedia_en_ray_charles": {"title": "Ray Charles"},
-        "wikipedia_en_all": {"title": "Wikipedia"},
+    assert set(config.zims) == {
+        ZimConfig(
+            title="Super content",
+            host="kiwix.renaud.test",
+            zim_name="super.zim_2023-05",
+        ),
+        ZimConfig(
+            title="Ray Charles",
+            host="kiwix.renaud.test",
+            zim_name="wikipedia_en_ray_charles",
+        ),
+        ZimConfig(
+            title="Wikipedia", host="kiwix.renaud.test", zim_name="wikipedia_en_all"
+        ),
     }
-    assert config.zim_host == "kiwix.renaud.test"
-    assert config.edupi_hosts == ["edupi1.renaud.test", "edupi2.renaud.test"]
+    assert set(config.apps) == {
+        AppConfig(
+            title="Shared files 1",
+            host="edupi1.renaud.test",
+            ident="edupi.offspot.kiwix.org",
+        ),
+        AppConfig(
+            title="Shared files 2",
+            host="edupi2.renaud.test",
+            ident="edupi.offspot.kiwix.org",
+        ),
+        AppConfig(
+            title="Wikifundi",
+            host="wikifundi.renaud.test",
+            ident="wikifundi-en.offspot.kiwix.org",
+        ),
+    }
 
 
 def test_parsing_warnings(
@@ -54,14 +88,30 @@ def test_parsing_warnings(
         "Package with missing 'title' ignored",
         "Unsupported URL: tata",
         "Package with missing 'kind' ignored",
-        "Ignoring second zim host 'kaka.renaud.test', only one host supported",
         "Unsupported ZIM URL: //kiwix.renaud.test/kkkk#toto",
         "Package with unsupported 'kind' : 'ooo' ignored",
-        "Ignoring unknown app ident 'wikifundi-en.offspot.kiwix.org'",
     ]
-    assert config.files == {}
-    assert config.zims == {
-        "wikipedia_en_all": {"title": "Wikipedia"},
+    assert config.files == []
+    assert set(config.zims) == {
+        ZimConfig(
+            title="Wikipedia", host="kiwix.renaud.test", zim_name="wikipedia_en_all"
+        ),
+        ZimConfig(title="toto title", host="kaka.renaud.test", zim_name="toto"),
     }
-    assert config.zim_host == "kiwix.renaud.test"
-    assert config.edupi_hosts == ["edupi.renaud.test", "edupi2.renaud.test"]
+    assert set(config.apps) == {
+        AppConfig(
+            title="Shared files",
+            host="edupi.renaud.test",
+            ident="edupi.offspot.kiwix.org",
+        ),
+        AppConfig(
+            title="Shared files 2",
+            host="edupi2.renaud.test",
+            ident="edupi.offspot.kiwix.org",
+        ),
+        AppConfig(
+            title="Wikifundi",
+            host="wikifundi.renaud.test",
+            ident="wikifundi-en.offspot.kiwix.org",
+        ),
+    }

--- a/backend/tests/unit/conf_files/conf_ok.yaml
+++ b/backend/tests/unit/conf_files/conf_ok.yaml
@@ -63,3 +63,7 @@ packages:
   ident: edupi.offspot.kiwix.org
   title: Shared files 2
   url: //edupi2.renaud.test/
+- kind: app
+  ident: wikifundi-en.offspot.kiwix.org
+  title: Wikifundi
+  url: //wikifundi.renaud.test/

--- a/backend/tests/unit/conf_files/conf_with_warnings.yaml
+++ b/backend/tests/unit/conf_files/conf_with_warnings.yaml
@@ -21,10 +21,10 @@ packages:
 - url: //kiwix.renaud.test/viewer#wikipedia_en_all
   title: toto
 
-# second ZIM host ignored
+# second ZIM host ok
 - kind: zim
   url: //kaka.renaud.test/viewer#toto
-  title: toto
+  title: toto title
 
 # incorrect ZIM URL
 - kind: zim
@@ -48,7 +48,7 @@ packages:
   title: Shared files 2
   url: //edupi2.renaud.test/
 
-# Unknown app ident
+# Unknown app ident ok
 - kind: app
   ident: wikifundi-en.offspot.kiwix.org
   title: Wikifundi


### PR DESCRIPTION
## Rationale
- this is preparatory work before implementing `AverageUsage` indicator which needs more info (timestamp) and all events on all packages (instead of just homepage)
- for some inputs (for usage data indeed, coming next), we will need to have access to the timestamp where the action occurred
- logic generating inputs from log lines was too coupled to Caddy + not enough generic to easily accommodates new kind of packages / generate new kind of inputs

## Changes
- new `InputWithTime` input (not necessarily coupled to a timestamp coming from a Caddy log, typically here we use it for the `ClockTickInput` where timestamp comes from the system clock)
- adapations of `ClockTickInput` to use this new generic class
- simplification of `ReverseProxyConfig` to generate real typed objects instead of weird dict[str,Any] and stuff like that + generation of generic config information, no need at this stage to decide what we will do from this information
- creation of the `InputGenerator` and its subclasses to extract the logic converting logs to inputs from `CaddyLogConverter`
- creation of the generic `LogData` class which now serves as an intermediate between `CaddyLogConverter` and `InputGenerator` subclasses
- tests adaptations to compare sets (unordered) for `ReverseProxyConfig` + add `ts` info in Caddy logs