### PR TITLE
Shared files tile

### DIFF
--- a/backend/src/offspot_metrics_backend/business/period.py
+++ b/backend/src/offspot_metrics_backend/business/period.py
@@ -89,6 +89,29 @@ class Period:
         # forget to modify this function
         raise AttributeError  # pragma: no cover
 
+    @classmethod
+    def from_truncated_value(cls, truncated_value: str, agg_kind: AggKind) -> "Period":
+        """Transform a truncated value into a period
+
+        First period of the truncated value is returned.
+        """
+
+        def get_period(value: str, timeformat: str) -> Period:
+            return Period(
+                datetime.datetime.strptime(value, timeformat).replace(
+                    tzinfo=datetime.UTC
+                )
+            )
+
+        if agg_kind == AggKind.DAY:
+            return get_period(truncated_value, "%Y-%m-%d")
+        elif agg_kind == AggKind.WEEK:
+            return get_period(f"{truncated_value} 1", "%Y W%W %w")
+        elif agg_kind == AggKind.MONTH:
+            return get_period(f"{truncated_value}-01", "%Y-%m-%d")
+        elif agg_kind == AggKind.YEAR:  # pragma: no branch
+            return get_period(f"{truncated_value}-01-01", "%Y-%m-%d")
+
     def get_interval(self, agg_kind: AggKind) -> Interval:
         """Transform the period into an interval matching the kind of aggregation
 

--- a/backend/src/offspot_metrics_backend/business/period.py
+++ b/backend/src/offspot_metrics_backend/business/period.py
@@ -94,6 +94,12 @@ class Period:
         """Transform a truncated value into a period
 
         First period of the truncated value is returned.
+
+        Examples:
+        - "2023" + YEAR => "2023-01-01 00:00:00"
+        - "2023-12" + MONTH => "2023-12-01 00:00:00",
+        - "2023 W12 + WEEK => "2023-03-20 00:00:00"
+        - "2023-12-25" + DAY => "2023-12-25 00:00:00",
         """
 
         def get_period(value: str, timeformat: str) -> Period:

--- a/backend/src/offspot_metrics_backend/routes/schemas.py
+++ b/backend/src/offspot_metrics_backend/routes/schemas.py
@@ -32,6 +32,7 @@ class AggregationsByKind(CamelModel):
 
     agg_kind: AggKind
     values_available: list[str]
+    values_all: list[str]
     kpis: list["KpiValues"]
 
     class KpiValueByAggregation(CamelModel):

--- a/backend/tests/unit/business/indicators/test_periods.py
+++ b/backend/tests/unit/business/indicators/test_periods.py
@@ -63,5 +63,20 @@ def test_periods(
         ("2023-06-08 10:18:12", AggKind.DAY, "2023-06-08"),
     ],
 )
-def test_truncated_value(curdate: str, kind: AggKind, expected: str) -> None:
+def test_get_truncated_value(curdate: str, kind: AggKind, expected: str) -> None:
     assert Period(datetime.fromisoformat(curdate)).get_truncated_value(kind) == expected
+
+
+@pytest.mark.parametrize(
+    "truncated,kind,expected",
+    [
+        ("2023", AggKind.YEAR, "2023-01-01 00:00:00"),
+        ("2023-12", AggKind.MONTH, "2023-12-01 00:00:00"),
+        ("2023 W12", AggKind.WEEK, "2023-03-20 00:00:00"),
+        ("2023-12-25", AggKind.DAY, "2023-12-25 00:00:00"),
+    ],
+)
+def test_from_truncated_value(truncated: str, kind: AggKind, expected: str) -> None:
+    assert Period.from_truncated_value(
+        truncated_value=truncated, agg_kind=kind
+    ) == Period(datetime.fromisoformat(expected))

--- a/backend/tests/unit/routes/test_aggregations_endpoints.py
+++ b/backend/tests/unit/routes/test_aggregations_endpoints.py
@@ -16,6 +16,7 @@ from offspot_metrics_backend.routes.aggregations import get_all_values
         (AggKind.MONTH, [], []),
         (AggKind.YEAR, ["2023"], ["2023"]),
         (AggKind.YEAR, ["2023", "2024"], ["2023", "2024"]),
+        (AggKind.YEAR, ["2023", "2026"], ["2023", "2024", "2025", "2026"]),
         (AggKind.MONTH, ["2023-02"], ["2022-12", "2023-01", "2023-02"]),
         (AggKind.WEEK, ["2023 W02"], ["2022 W51", "2022 W52", "2023 W01", "2023 W02"]),
         (

--- a/frontend/src/components/DashboardSharedFiles.vue
+++ b/frontend/src/components/DashboardSharedFiles.vue
@@ -1,12 +1,110 @@
 <script setup lang="ts">
-import { useMainStore } from '../stores/main'
-import { kpiIds } from '../constants'
-const store = useMainStore()
+import VueApexCharts from 'vue3-apexcharts'
+import { useSharedFilesStore } from '../stores/sharedFiles'
+import { computed } from 'vue'
+const sharedFilesStore = useSharedFilesStore()
+
+const chartOptions = computed(() => {
+  return {
+    chart: {
+      height: 253,
+      type: 'line',
+      zoom: {
+        enabled: false,
+      },
+      animations: {
+        enabled: false,
+      },
+      toolbar: {
+        show: false,
+      },
+    },
+    legend: {
+      horizontalAlign: 'left',
+      markers: {
+        width: 25,
+        height: 3,
+        offsetY: -2,
+        offsetX: -6,
+      },
+      itemMargin: {
+        horizontal: 15,
+      },
+    },
+    stroke: {
+      width: [3, 3],
+      curve: 'straight',
+    },
+    colors: ['#28c56f', '#ca0033'],
+    labels: sharedFilesStore.labels,
+    markers: {
+      size: 3,
+      colors: 'white',
+      strokeColors: ['#28c56f', '#ca0033'],
+      strokeWidth: 3,
+      strokeOpacity: 1,
+      hover: {
+        sizeOffset: 2,
+      },
+    },
+    xaxis: {
+      axisBorder: {
+        show: false,
+      },
+      labels: {
+        show: false,
+      },
+      tooltip: {
+        enabled: false,
+      },
+    },
+    yaxis: {
+      labels: {
+        show: false,
+      },
+    },
+    grid: {
+      strokeDashArray: 7,
+      xaxis: {
+        lines: {
+          show: true,
+        },
+      },
+      yaxis: {
+        lines: {
+          show: false,
+        },
+      },
+    },
+  }
+})
+
+const series = computed(() => {
+  return [
+    {
+      name: 'Added',
+      data: sharedFilesStore.values?.map((value) =>
+        value ? value.filesCreated : null,
+      ),
+    },
+    {
+      name: 'Removed',
+      data: sharedFilesStore.values?.map((value) =>
+        value ? value.filesDeleted : null,
+      ),
+    },
+  ]
+})
 </script>
 
 <template>
-  <h4>Shared Files:</h4>
-  <code>{{ store.getAllKpiValues(kpiIds.sharedFiles) }}</code>
+  <v-card-title>Shared Files</v-card-title>
+  <VueApexCharts
+    id="box"
+    :options="chartOptions"
+    :series="series"
+    height="253px"
+  />
 </template>
 
 <style scoped>

--- a/frontend/src/stores/main.ts
+++ b/frontend/src/stores/main.ts
@@ -40,6 +40,12 @@ export const useMainStore = defineStore('main', {
           state.aggregationsDetails.valuesAvailable.length - 1
         : false,
     hasPrevAggregationValue: (state) => state.aggregationValueIndex > 0,
+    getAllAggValues(state) {
+      if (!state.aggregationsDetails) {
+        return null
+      }
+      return state.aggregationsDetails.valuesAll
+    },
     getAllKpiValues(state) {
       return (kpiId: number): AggregationKpiValue[] | null => {
         if (!state.aggregationsDetails || !this.aggregationValue) {
@@ -54,19 +60,30 @@ export const useMainStore = defineStore('main', {
         return kpisMatch[0].values
       }
     },
-    getCurrentKpiValue() {
-      return (kpiId: number): AggregationKpiValue | null => {
+    getKpiValue() {
+      return (
+        kpiId: number,
+        aggregationValue: string,
+      ): AggregationKpiValue | null => {
         const currentValues = this.getAllKpiValues(kpiId)
         if (!currentValues) {
           return null
         }
         const kpisMatch = currentValues.filter(
-          (value) => value.aggValue == this.aggregationValue,
+          (value) => value.aggValue == aggregationValue,
         )
         if (kpisMatch.length != 1) {
           return null
         }
         return kpisMatch[0]
+      }
+    },
+    getCurrentKpiValue() {
+      return (kpiId: number): AggregationKpiValue | null => {
+        if (!this.aggregationValue) {
+          return null
+        }
+        return this.getKpiValue(kpiId, this.aggregationValue)
       }
     },
     getPackageColor(state) {

--- a/frontend/src/stores/sharedFiles.ts
+++ b/frontend/src/stores/sharedFiles.ts
@@ -6,12 +6,10 @@ import SharedFilesKpiValue from '@/types/SharedFilesKpiValue'
 export const useSharedFilesStore = defineStore('sharedFiles', {
   getters: {
     aggregationValue() {
-      const mainStore = useMainStore()
-      return mainStore.aggregationValue
+      return useMainStore().aggregationValue
     },
     labels() {
-      const mainStore = useMainStore()
-      return mainStore.getAllAggValues
+      return useMainStore().getAllAggValues
     },
     values() {
       const mainStore = useMainStore()

--- a/frontend/src/stores/sharedFiles.ts
+++ b/frontend/src/stores/sharedFiles.ts
@@ -1,0 +1,25 @@
+import { useMainStore } from './main'
+import { defineStore } from 'pinia'
+import { kpiIds } from '../constants'
+import SharedFilesKpiValue from '@/types/SharedFilesKpiValue'
+
+export const useSharedFilesStore = defineStore('sharedFiles', {
+  getters: {
+    aggregationValue() {
+      const mainStore = useMainStore()
+      return mainStore.aggregationValue
+    },
+    labels() {
+      const mainStore = useMainStore()
+      return mainStore.getAllAggValues
+    },
+    values() {
+      const mainStore = useMainStore()
+      return mainStore.getAllAggValues?.map(
+        (aggValue) =>
+          mainStore.getKpiValue(kpiIds.sharedFiles, aggValue)
+            ?.kpiValue as SharedFilesKpiValue,
+      )
+    },
+  },
+})

--- a/frontend/src/types/AggregationDetails.ts
+++ b/frontend/src/types/AggregationDetails.ts
@@ -6,5 +6,6 @@ import AggregationKpi from './AggregationKpi'
 export default interface AggregationDetails {
   aggKind: string
   valuesAvailable: string[]
+  valuesAll: string[]
   kpis: AggregationKpi[]
 }

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -20,6 +20,11 @@ import DashboardUptime from '../components/DashboardUptime.vue'
             <v-col cols="12">
               <v-card elevation="0"> <DashboardSharedFiles /> </v-card
             ></v-col>
+            <v-col cols="12" class="d-lg-none">
+              <v-card elevation="0">
+                <DashboardTotalUsage />
+              </v-card>
+            </v-col>
           </v-row>
         </v-container>
       </v-col>
@@ -31,7 +36,7 @@ import DashboardUptime from '../components/DashboardUptime.vue'
                 <DashboardPackagePopularity />
               </v-card>
             </v-col>
-            <v-col cols="12" lg="6">
+            <v-col cols="12" lg="6" class="d-md-none d-lg-flex">
               <v-card elevation="0">
                 <DashboardTotalUsage />
               </v-card>


### PR DESCRIPTION
## Rationale

Fix #49

## Changes
- Minimal UI for the Shared Files dashboard tile (not corresponding exactly to the expected design, especially in terms of tooltips)
- Modify the backend API `GET /aggregations/{aggregationKind}` to return `allValues` which contains all aggregation values, even if no KPI data is available for some of these values (allow to centralize the logic about the number of KPIs kept per kind of aggregation in the backend instead of computing this in the frontend)
- Fix the dashboard layout for `md` screens sizes
