### PR TITLE
Create Docker container

### DIFF
--- a/.github/workflows/Publish.yaml
+++ b/.github/workflows/Publish.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: openzim/docker-publish-action@v10
         with:
           context: backend
-          image-name: offspot/metrics_backend
+          image-name: offspot/metrics
           tag-pattern: /^v([0-9.]+)$/
           latest-on-tag: true
           restrict-to: offspot/metrics

--- a/.github/workflows/PublishDockerDevImage.yaml
+++ b/.github/workflows/PublishDockerDevImage.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: openzim/docker-publish-action@v10
         with:
           context: backend
-          image-name: offspot/metrics_backend
+          image-name: offspot/metrics
           manual-tag: dev
           latest-on-tag: false
           restrict-to: offspot/metrics

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -42,14 +42,13 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Ensure we can build the Docker image
-        working-directory: backend
         run: |
-          docker build -t offspot_metrics_backend .
+          docker build -t offspot_metrics .
 
       - name: Ensure we can start the Docker image
         run: |
           echo "Starting the container"
-          docker run -d --name test_container -e PROCESSING_DISABLED='True' offspot_metrics_backend
+          docker run -d --name test_container -e PROCESSING_DISABLED='True' offspot_metrics
           echo "Waiting 5 seconds"
           sleep 5
           echo "Checking container logs"

--- a/backend/src/offspot_metrics_backend/constants.py
+++ b/backend/src/offspot_metrics_backend/constants.py
@@ -34,3 +34,5 @@ class BackendConf:
     logwatcher_data_folder = os.getenv(
         "LOGWATCHER_DATA_FOLDER", f"{src_dir}/logwatcher-data"
     )
+
+    ui_location = pathlib.Path(os.getenv("UI_LOCATION", "/src/ui"))

--- a/backend/tests/unit/routes/conftest.py
+++ b/backend/tests/unit/routes/conftest.py
@@ -52,7 +52,7 @@ def app(reverse_proxy_config: Callable[[str | None], ReverseProxyConfig]):
 
 @pytest_asyncio.fixture()  # pyright: ignore
 async def client(app: FastAPI) -> AsyncGenerator[AsyncClient, Any]:
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    async with AsyncClient(app=app, base_url="http://test/api") as client:
         yield client
 
 

--- a/backend/tests/unit/routes/test_root_endpoint.py
+++ b/backend/tests/unit/routes/test_root_endpoint.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 import pytest
 from httpx import AsyncClient
 
@@ -6,8 +8,10 @@ from offspot_metrics_backend.main import PREFIX
 
 @pytest.mark.asyncio
 async def test_root(client: AsyncClient):
+    response = await client.get("", follow_redirects=False)
+    assert response.status_code == HTTPStatus.TEMPORARY_REDIRECT
     response = await client.get("/", follow_redirects=False)
-    assert response.status_code == 308
+    assert response.status_code == HTTPStatus.TEMPORARY_REDIRECT
     response = await client.get("/", follow_redirects=True)
     assert str(response.url).endswith(PREFIX + "/")
     assert response.headers.get("Content-Type") == "text/html; charset=utf-8"

--- a/dev/README.md
+++ b/dev/README.md
@@ -7,6 +7,7 @@ It is recommended to use it in combination with Mutagen to effeciently sync data
 - Reverse proxy ("fake"): http://localhost:8000
 - Kiwix-serve ("fake"): http://localhost:8001
 - Application: http://localhost:8002
+- Dev Backend/API: http://localhost:8002/api/
 - Dev Frontend: http://localhost:8003
 - Edupi ("fake"): http://localhost:8004
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -6,15 +6,19 @@ It is recommended to use it in combination with Mutagen to effeciently sync data
 
 - Reverse proxy ("fake"): http://localhost:8000
 - Kiwix-serve ("fake"): http://localhost:8001
-- Backend API: http://localhost:8002
+- Application: http://localhost:8002
 - Dev Frontend: http://localhost:8003
 - Edupi ("fake"): http://localhost:8004
 
 ## List of containers
 
-### backend
+### metrics
 
-This container is the backend web server.
+This container is the full application (UI + API), close to the real production container.
+
+Python code is mounted inside the container and hot-reloaded (i.e. API development can be tested on this).
+
+UI is statically compiled, so changes are not refreshed, use the frontend-tools UI for testing UI changes.
 
 ### backend-tools
 
@@ -30,7 +34,7 @@ Context is setup with appropriate environment variables:
 
 This container hosts the development frontend UI (i.e. `yarn dev`).
 
-It is not the statically compiled version.
+It is not the statically compiled version, so it is very usefull to test UI changes locally.
 
 ### kiwix-serve
 
@@ -109,14 +113,14 @@ docker compose -p offspot_metrics up -d --force-recreate backend
 
 You can then browse packages at http://127.0.0.1:8000/ and statistics will show up after up to 1 hour in the web UI at http://127.0.0.1:8003/
 
-### Restart the backend
+### Restart the application
 
-The backend might typically fail if the DB schema is not up-to-date, or if you create some nasty bug while modifying the code.
+The application might typically fail if the DB schema is not up-to-date, or if you create some nasty bug while modifying the code.
 
 Restart it with:
 
 ```sh
-docker restart om_backend
+docker restart om_metrics
 ```
 
 Other containers might be restarted the same way.

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
-  backend:
-    build: ../backend
-    container_name: om_backend
+  metrics:
+    build: ..
+    container_name: om_metrics
     volumes:
       - ../backend/src/offspot_metrics_backend:/usr/local/lib/python3.11/site-packages/offspot_metrics_backend
       - reverse-proxy-srv:/reverse-proxy-logs

--- a/dev/frontend-tools/Dockerfile
+++ b/dev/frontend-tools/Dockerfile
@@ -5,5 +5,5 @@ WORKDIR /work
 COPY . /work
 RUN yarn
 ENV NODE_ENV=dev
-ENV VITE_BACKEND_ROOT_API http://localhost:8002/v1
+ENV VITE_BACKEND_ROOT_API http://localhost:8002/api/v1
 CMD ["yarn", "dev", "--host", "0.0.0.0", "--port", "5173"]


### PR DESCRIPTION
## Rationale

Fix #67 

## Changes
- We build one single Docker image with both the frontend and the backend
- The frontend is served by uvicorn thanks to a custom middleware, including support for Vue.JS routes refresh / bookmarks
- In dev, the `backend` container is renamed `metrics` since it now contains the whole app ; some explanations around development process for frontend / backend are added
- Of course, Github workflow is adapted to the fact we now have one single image
- Redirect from homepage has been adapted:
  - We redirect only `/api` to `/api/v1`
  - We now redirect with a temporary redirect (the permanent one was an error, and we do not really mind to use a temporary one, this redirect is not used by production anyway, it is just a convenient helper, mostly for devs)
  - We redirect both `/api` and `/api/`