### PR TITLE
Migrate to Alpine instead of Debian slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY frontend /src
 RUN yarn install --frozen-lockfile
 RUN VITE_BACKEND_ROOT_API="./api/v1" yarn build
 
-FROM python:3.11-slim-bookworm
+FROM python:3.11-alpine
 LABEL org.opencontainers.image.source https://github.com/offspot/metrics
 
 # Specifying a workdir which is not "/"" is mandatory for proper uvicorn watchfiles


### PR DESCRIPTION
## Rationale

Fix #72 

## Changes

- change Docker base image (only for prod image, dev tools are still based on Debian slim for convenience)