### PR TITLE
Adapt UI to small screens

### DIFF
--- a/frontend/src/components/AggregationSelectorSmallScreen.vue
+++ b/frontend/src/components/AggregationSelectorSmallScreen.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useMainStore } from '../stores/main'
+
+const mainStore = useMainStore()
+const isOpen = ref(false)
+
+const toggleOpen = () => {
+  isOpen.value = !isOpen.value
+}
+
+const height = computed(() => (isOpen.value ? '200px' : '10px'))
+</script>
+
+<template>
+  <div id="selector1" :style="{ height: height }">
+    <div v-if="isOpen">
+      <div id="select-timeline" class="pt-2 pb-2">Select timeline</div>
+      <div id="agg-selector">
+        <v-btn-toggle
+          divided
+          mandatory
+          density="compact"
+          rounded
+          :model-value="mainStore.aggregationKind"
+          @update:model-value="
+            (newValue) => mainStore.setAggregationKind(newValue)
+          "
+        >
+          <v-btn value="D"> Day </v-btn>
+
+          <v-btn value="W"> Week </v-btn>
+
+          <v-btn value="M"> Month </v-btn>
+
+          <v-btn value="Y"> Year </v-btn>
+        </v-btn-toggle>
+      </div>
+      <div class="pt-4 pb-4 font-weight-bold">
+        {{ mainStore.date_part_1 }}{{ mainStore.date_part_2
+        }}{{ mainStore.date_part_3_short }}
+      </div>
+      <div id="prev-next">
+        <v-btn
+          min-width="10em"
+          prepend-icon="fas fa-arrow-left"
+          variant="flat"
+          :disabled="!mainStore.hasPrevAggregationValue"
+          @click="mainStore.toPreviousAggregrationValue"
+        >
+          Previous
+        </v-btn>
+        <span>&nbsp;</span>
+        <v-btn
+          min-width="10em"
+          append-icon="fas fa-arrow-right"
+          variant="flat"
+          :disabled="!mainStore.hasNextAggregationValue"
+          @click="mainStore.toNextAggregationValue"
+        >
+          Next
+        </v-btn>
+      </div>
+    </div>
+  </div>
+  <div id="selector2" @click="toggleOpen">
+    <span v-if="isOpen">APPLY</span>
+    <span v-else
+      >{{ mainStore.date_part_1 }}{{ mainStore.date_part_2
+      }}{{ mainStore.date_part_3_short }}</span
+    >
+  </div>
+</template>
+
+<style scoped>
+#selector1 {
+  background-color: #7266ed;
+  text-align: center;
+  color: white;
+}
+#selector2 {
+  background-color: #7266ed;
+  width: 120px;
+  color: white;
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+  border-radius: 0 0 6px 6px;
+}
+#select-timeline {
+  width: 300px;
+  text-align: left;
+  margin-left: auto;
+  margin-right: auto;
+  font-size: 0.9rem !important;
+}
+
+#agg-selector .v-btn-group {
+  border-radius: 20px;
+}
+
+#agg-selector .v-btn {
+  text-transform: none;
+  background-color: #4f4ad6;
+  color: white;
+}
+
+#agg-selector .v-btn--active {
+  background-color: #2d2f90;
+}
+
+#prev-next .v-btn {
+  border-radius: 30px;
+  text-transform: none;
+  background-color: #4f4bed;
+  color: white;
+}
+
+#prev-next .v-btn--disabled {
+  background-color: #e2e1e4;
+}
+</style>

--- a/frontend/src/components/AppBarBigScreen.vue
+++ b/frontend/src/components/AppBarBigScreen.vue
@@ -4,13 +4,18 @@ const store = useMainStore()
 </script>
 
 <template>
-  <v-col cols="12" class="py-2 d-flex align-center">
-    <div class="flex-0-1">
+  <v-col cols="12" class="d-flex py-2 align-center">
+    <v-app-bar-nav-icon
+      class="d-lg-none"
+      @click="store.toggleDrawerVisibility()"
+    ></v-app-bar-nav-icon>
+    <div id="agg-selector" class="flex-0-1">
       <v-btn-toggle
-        color="deep-purple-accent-2"
+        class="ml-6"
         divided
         mandatory
         density="compact"
+        rounded
         :model-value="store.aggregationKind"
         @update:model-value="(newValue) => store.setAggregationKind(newValue)"
       >
@@ -23,13 +28,14 @@ const store = useMainStore()
         <v-btn value="Y"> Year </v-btn>
       </v-btn-toggle>
     </div>
-    <div class="flex-1-1">
-      <!-- Hidden for now, to be reworked once we create the real slider-->
-      <span class="hidden">{{ store.aggregationValue }}</span>
+    <div id="agg-value" class="flex-1-1">
+      <span
+        >{{ store.date_part_1 }}{{ store.date_part_2
+        }}{{ store.date_part_3 }}</span
+      >
     </div>
-    <div class="flex-0-1">
+    <div id="prev-next" class="flex-0-1">
       <v-btn
-        color="indigo-darken-1"
         min-width="10em"
         prepend-icon="fas fa-arrow-left"
         variant="flat"
@@ -40,7 +46,6 @@ const store = useMainStore()
       </v-btn>
       <span>&nbsp;</span>
       <v-btn
-        color="indigo-darken-1"
         min-width="10em"
         append-icon="fas fa-arrow-right"
         variant="flat"
@@ -56,5 +61,34 @@ const store = useMainStore()
 <style scoped>
 .hidden {
   display: none;
+}
+
+#agg-value {
+  text-align: center;
+}
+
+#agg-selector .v-btn-group {
+  border-radius: 20px;
+}
+
+#agg-selector .v-btn {
+  text-transform: none;
+  background-color: rgba(24, 24, 179, 0.34);
+  color: #3858cc;
+}
+
+#agg-selector .v-btn--active {
+  background-color: #dbdafb;
+}
+
+#prev-next .v-btn {
+  border-radius: 30px;
+  text-transform: none;
+  background-color: #4f4bed;
+  color: white;
+}
+
+#prev-next .v-btn--disabled {
+  background-color: #d9d7e2;
 }
 </style>

--- a/frontend/src/components/AppBarSmallScreen.vue
+++ b/frontend/src/components/AppBarSmallScreen.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { useMainStore } from '../stores/main'
+const store = useMainStore()
+</script>
+
+<template>
+  <v-col cols="12" class="d-flex py-2 align-center">
+    <div class="d-flex ma-2 mb-0 align-center">
+      <v-img :height="30" width="30" src="./Kiwix_logo_v3.svg"></v-img>
+      <div class="pl-2 flex-1-1-100">
+        <span class="float-left font-weight-black text-h6">Metrics</span>
+      </div>
+    </div>
+    <div class="flex-1-1"></div>
+    <v-app-bar-nav-icon
+      class="d-lg-none"
+      @click="store.toggleDrawerVisibility()"
+    ></v-app-bar-nav-icon>
+  </v-col>
+</template>
+
+<style scoped></style>

--- a/frontend/src/components/DashboardUptime.vue
+++ b/frontend/src/components/DashboardUptime.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import VueApexCharts from 'vue3-apexcharts'
 import { useUptimeStore } from '../stores/uptime'
+import { useMainStore } from '../stores/main'
 import { computed } from 'vue'
 const uptimeStore = useUptimeStore()
+const mainStore = useMainStore()
 
 const chartOptions = computed(() => {
   return {
@@ -66,13 +68,11 @@ const chartOptions = computed(() => {
     <v-card-subtitle class="pt-2">During selected period</v-card-subtitle>
     <v-card-text>
       <span class="text-subtitle-1 font-weight-medium">{{
-        uptimeStore.date_part_1
+        mainStore.date_part_1
       }}</span>
-      <span class="text-h5 font-weight-bold">{{
-        uptimeStore.date_part_2
-      }}</span>
+      <span class="text-h5 font-weight-bold">{{ mainStore.date_part_2 }}</span>
       <span class="text-subtitle-1 font-weight-medium">{{
-        uptimeStore.date_part_3
+        mainStore.date_part_3
       }}</span>
     </v-card-text>
   </div>
@@ -91,7 +91,7 @@ const chartOptions = computed(() => {
   top: -20px;
   right: -50px;
 }
-.data.v-card-text {
+.data .v-card-text {
   position: absolute;
   bottom: 0px;
 }

--- a/frontend/src/components/DrawerItem.vue
+++ b/frontend/src/components/DrawerItem.vue
@@ -16,6 +16,10 @@ defineProps({
     type: String,
     required: true,
   },
+  activeClass: {
+    type: String,
+    required: true,
+  },
 })
 </script>
 
@@ -23,6 +27,7 @@ defineProps({
   <v-list-item
     :active="store.currentPage == value"
     link
+    :active-class="activeClass"
     class="rounded-lg mx-2 py-0"
     @click="store.currentPage = value"
   >
@@ -35,4 +40,8 @@ defineProps({
   </v-list-item>
 </template>
 
-<style scoped></style>
+<style scoped>
+.active-small {
+  background-color: #dbdafb;
+}
+</style>

--- a/frontend/src/stores/uptime.ts
+++ b/frontend/src/stores/uptime.ts
@@ -3,45 +3,10 @@ import { useMainStore } from './main'
 import { defineStore } from 'pinia'
 import { kpiIds } from '../constants'
 
-// Hard-coded for now, to be reworked once we will need this also for the slider
-const monthText = (monthDigit: string): string => {
-  switch (monthDigit) {
-    case '01':
-      return 'January'
-    case '02':
-      return 'February'
-    case '03':
-      return 'March'
-    case '04':
-      return 'April'
-    case '05':
-      return 'May'
-    case '06':
-      return 'June'
-    case '07':
-      return 'July'
-    case '08':
-      return 'August'
-    case '09':
-      return 'September'
-    case '10':
-      return 'October'
-    case '11':
-      return 'November'
-    case '12':
-      return 'December'
-    default:
-      return ''
-  }
-}
-
 export const useUptimeStore = defineStore('uptime', {
   getters: {
     aggregationKind() {
       return useMainStore().aggregationKind
-    },
-    aggregationValue() {
-      return useMainStore().aggregationValue || ''
     },
     kpiValue() {
       return useMainStore().getCurrentKpiValue(kpiIds.uptime)
@@ -74,65 +39,6 @@ export const useUptimeStore = defineStore('uptime', {
         return (this.kpiValue.nbMinutesOn / 60).toFixed(1) + 'h'
       } else {
         return (this.kpiValue.nbMinutesOn / 60).toFixed(0) + 'h'
-      }
-    },
-    /*
-      The date displayed on the uptime tile is splitted in 3 parts:
-      - date_part_1 which is in normal font weight
-      - date_part_2 which is in bold font weight
-      - date_part_3 which is in normal font weight
-      All three are computed based on current aggregation kind and value,
-      based on our internal convention on aggregation values formats.
-    */
-    date_part_1(): string {
-      switch (this.aggregationKind) {
-        case 'D':
-          return ''
-        case 'W':
-          return 'Week '
-        case 'M':
-          return ''
-        case 'Y':
-          return 'Year '
-        default:
-          return ''
-      }
-    },
-    // See above
-    date_part_2(): string {
-      switch (this.aggregationKind) {
-        case 'D':
-          return this.aggregationValue.split('-')[2] + ' '
-        case 'W':
-          if (this.aggregationValue.indexOf(' ') < 0) {
-            return '' // Race condition where space is not yet available
-          }
-          return this.aggregationValue.split(' ')[1].substring(1) + ' '
-        case 'M':
-          return monthText(this.aggregationValue.split('-')[1]) + ' '
-        case 'Y':
-          return this.aggregationValue
-        default:
-          return ''
-      }
-    },
-    // See above
-    date_part_3(): string {
-      switch (this.aggregationKind) {
-        case 'D':
-          return (
-            monthText(this.aggregationValue.split('-')[1]) +
-            ' ' +
-            this.aggregationValue.split('-')[0]
-          )
-        case 'W':
-          return this.aggregationValue.split(' ')[0]
-        case 'M':
-          return this.aggregationValue.split('-')[0]
-        case 'Y':
-          return ''
-        default:
-          return ''
       }
     },
   },

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,5 +1,4 @@
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1,23 +1,35 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 import DrawerItem from '../components/DrawerItem.vue'
-import AggregationSelector from '../components/AggregationSelector.vue'
+import AppBarSmallScreen from '../components/AppBarSmallScreen.vue'
+import AppBarBigScreen from '../components/AppBarBigScreen.vue'
+import AggregationSelectorSmallScreen from '../components/AggregationSelectorSmallScreen.vue'
 import Dashboard from '../views/Dashboard.vue'
 import PackagePopularity from '../views/PackagePopularity.vue'
 import TotalUsage from '../views/TotalUsage.vue'
 
-import { onMounted, ref } from 'vue'
+import { onMounted, computed } from 'vue'
 import { useMainStore, Page } from '../stores/main'
+import { useDisplay } from 'vuetify'
+
+const { mdAndUp, lgAndUp } = useDisplay()
 const store = useMainStore()
-const drawer = ref(true)
 onMounted(() => {
   store.fetchAggregationDetails()
+  store.setDrawerVisibility(lgAndUp.value) // at startutp, close drawer on small screens
 })
+
+const height = computed(() => (mdAndUp.value ? 100 : 60))
 </script>
 
 <template>
   <v-app v-if="store.aggregationsDetails" id="home">
-    <v-navigation-drawer v-model="drawer" class="pa-2">
+    <v-navigation-drawer
+      v-if="mdAndUp"
+      v-model="store.drawerVisible"
+      class="pa-2"
+      location="left"
+    >
       <div class="d-flex ma-4 mb-0 align-center">
         <v-img :width="60" src="./Kiwix_logo_v3.svg"></v-img>
         <div class="pl-2 flex-1-1-100">
@@ -29,28 +41,41 @@ onMounted(() => {
         title="Dashboard"
         :value="Page.Dashboard"
         icon="far fa-envelope-open"
+        active-class="active-big"
       />
     </v-navigation-drawer>
 
-    <v-app-bar flat height="100">
-      <v-app-bar-nav-icon
-        class="d-lg-none"
-        @click="drawer = !drawer"
-      ></v-app-bar-nav-icon>
-      <AggregationSelector />
+    <v-navigation-drawer
+      v-if="!mdAndUp"
+      v-model="store.drawerVisible"
+      class="small-drawer py-8 px-4"
+      location="right"
+    >
+      <div class="pb-4 px-2 font-weight-bold">Menu</div>
+      <v-icon
+        id="close-drawer"
+        icon="fas fa-xmark"
+        @click="store.toggleDrawerVisibility()"
+      ></v-icon>
+      <DrawerItem
+        class="py-6"
+        title="Dashboard"
+        :value="Page.Dashboard"
+        icon="far fa-envelope-open"
+        active-class="active-small"
+      />
+    </v-navigation-drawer>
+
+    <v-app-bar flat :height="height">
+      <AppBarBigScreen v-if="mdAndUp" />
+      <AppBarSmallScreen v-if="!mdAndUp" />
     </v-app-bar>
 
     <v-main>
+      <AggregationSelectorSmallScreen v-if="!mdAndUp" />
       <Dashboard v-if="store.currentPage == Page.Dashboard" />
       <PackagePopularity v-if="store.currentPage == Page.PackagePopularity" />
       <TotalUsage v-if="store.currentPage == Page.TotalUsage" />
-      <v-footer app class="text-caption">
-        <span class="font-weight-bold me-auto">© 2023 Kiwix Association</span>
-        <span class="me-8">Support</span>
-        <a href="https://www.kiwix.org" target="_blank"
-          ><span class="font-weight-bold flex-d-1-1-100">www.kiwix.org</span></a
-        >
-      </v-footer>
     </v-main>
   </v-app>
 </template>
@@ -60,15 +85,14 @@ onMounted(() => {
   background-color: rgb(248, 247, 250);
 }
 
-.v-footer {
-  background-color: rgb(243, 239, 245);
-}
-
-.v-footer a {
-  color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity));
-}
-
 .v-main {
   background-color: rgb(243, 239, 245);
+}
+
+#close-drawer {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  font-size: medium;
 }
 </style>


### PR DESCRIPTION
## Rationale

Fix #89 
Fix #77 
Fix #63

## Changes

- remove the footer which is not used (at least for now)
- fix colors and responsiveness of existing screens
- switch to Roboto font (which is the default for Vue.JS, so no need to specify one)
- implement top toolbar for mobile screens
- logic around computation of current date has been moved from uptime store to main store since it needs to be shared among components (and is hence not specific to the uptime component)
