### PR TITLE
Indicator processor: do not reprocess the same period when application restart

### DIFF
--- a/backend/dev_tools/perf_tests_howto.md
+++ b/backend/dev_tools/perf_tests_howto.md
@@ -196,7 +196,7 @@ rm -rf "$TMP_DIR/*"
 Wait for background processing to trigger yearly computation and complete. Note down execution duration.
 
 ```sh
-docker logs -f offspot_backend
+docker logs -f om_metrics
 ```
 
 Prepare data transfer and stock the stacks.

--- a/backend/src/offspot_metrics_backend/business/indicators/processor.py
+++ b/backend/src/offspot_metrics_backend/business/indicators/processor.py
@@ -97,6 +97,16 @@ class Processor:
         if not last_period:
             return
 
+        # check if we have indicator records for the last period ; if we have,
+        # then it means that everything has been recorded, we do not need to restore
+        # states (there are none anyway) and the current_period is the next after
+        # last_period
+        if Persister.has_indicator_records_for_period(
+            period=last_period, session=session
+        ):
+            self.current_period = last_period.get_next()
+            return
+
         # set current period as the last one and restore state from DB
         self.current_period = last_period
         for indicator in self.indicators:

--- a/backend/src/offspot_metrics_backend/business/period.py
+++ b/backend/src/offspot_metrics_backend/business/period.py
@@ -73,6 +73,10 @@ class Period:
         """Return a new period shifted from delta"""
         return Period(self.dt + delta)
 
+    def get_next(self) -> "Period":
+        """Return the next period"""
+        return Period(self.dt + datetime.timedelta(hours=1))
+
     def get_truncated_value(self, agg_kind: AggKind) -> str:
         """Truncate the period to corresponding day, week, month, year."""
         if agg_kind == AggKind.DAY:

--- a/backend/src/offspot_metrics_backend/db/persister.py
+++ b/backend/src/offspot_metrics_backend/db/persister.py
@@ -113,6 +113,17 @@ class Persister:
         )
 
     @classmethod
+    def has_indicator_records_for_period(cls, period: Period, session: Session) -> bool:
+        """Checks if we have indicator records for a given period"""
+        return (
+            session.query(RecordDb)
+            .join(PeriodDb)
+            .where(PeriodDb.timestamp == period.timestamp)
+            .count()
+            > 0
+        )
+
+    @classmethod
     def get_kpi_values(
         cls,
         kpi_id: int,

--- a/backend/tests/unit/business/indicators/test_periods.py
+++ b/backend/tests/unit/business/indicators/test_periods.py
@@ -86,3 +86,26 @@ def test_from_truncated_value(truncated: str, kind: AggKind, expected: str) -> N
     assert Period.from_truncated_value(
         truncated_value=truncated, agg_kind=kind
     ) == Period(datetime.fromisoformat(expected))
+
+
+@pytest.mark.parametrize(
+    "current_period,next_period",
+    [
+        (
+            "2023-01-01 00:00:00",
+            "2023-01-01 01:00:00",
+        ),
+        (
+            "2023-01-23 23:00:00",
+            "2023-01-24 00:00:00",
+        ),
+        (
+            "2023-12-31 23:00:00",
+            "2024-01-01 00:00:00",
+        ),
+    ],
+)
+def test_get_next(current_period: str, next_period: str) -> None:
+    assert Period(datetime.fromisoformat(current_period)).get_next() == Period(
+        datetime.fromisoformat(next_period)
+    )


### PR DESCRIPTION
## Rationale

Fix #97 

## Changes

- in indicator processor, detect if we have already processed the last period found in DB and act accordingly
- I have "augmented" the `test_restore_from_db_start_new_period_not_recorded` test to exercise the "usual" condition where we have not yet recorded the last period found in DB at application restart (test is GREEN even without code changes)
- I have add the `test_restore_from_db_start_new_period_recorded` test to exercise the "rare" condition where we have already recorded the last period found in DB at application restart (test is RED without the code changes)