### PR TITLE
Adopt file manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.1] - 2024-01-26
 
+### Added
+
+- Backend: add support for file-manager in addition to EduPi (#104)
+
 ### Fixed
 
 - Backend: Indicator processor sometimes re-process an already recorded period after an application restarts (#97)

--- a/backend/src/offspot_metrics_backend/business/indicators/processor.py
+++ b/backend/src/offspot_metrics_backend/business/indicators/processor.py
@@ -20,7 +20,7 @@ class Processor:
             try:
                 indicator.process_input(input_=input_)
             except Exception as exc:
-                logger.warn(
+                logger.warning(
                     f"Error processing input for indicator {indicator.unique_id}",
                     exc_info=exc,
                 )

--- a/backend/src/offspot_metrics_backend/business/indicators/shared_files.py
+++ b/backend/src/offspot_metrics_backend/business/indicators/shared_files.py
@@ -3,7 +3,7 @@ from typing import cast
 from offspot_metrics_backend.business.indicators.dimensions import DimensionsValues
 from offspot_metrics_backend.business.indicators.indicator import Indicator
 from offspot_metrics_backend.business.indicators.recorder import (
-    IntCounterRecorder,
+    CountCounterRecorder,
     Recorder,
 )
 from offspot_metrics_backend.business.inputs.input import Input
@@ -19,7 +19,7 @@ class SharedFilesOperations(Indicator):
         return isinstance(input_, SharedFilesOperation)
 
     def get_new_recorder(self) -> Recorder:
-        return IntCounterRecorder()
+        return CountCounterRecorder()
 
     def get_dimensions_values(self, input_: Input) -> DimensionsValues:
         input_ = cast(SharedFilesOperation, input_)

--- a/backend/src/offspot_metrics_backend/business/input_generator.py
+++ b/backend/src/offspot_metrics_backend/business/input_generator.py
@@ -78,7 +78,9 @@ class EdupiInputGenerator(InputGenerator):
         ):
             return [
                 PackageRequest(ts=log.ts, package_title=self.package_title),
-                SharedFilesOperation(kind=SharedFilesOperationKind.FILE_CREATED),
+                SharedFilesOperation(
+                    kind=SharedFilesOperationKind.FILE_CREATED, count=1
+                ),
             ]
         elif (
             log.method == "DELETE"
@@ -88,10 +90,40 @@ class EdupiInputGenerator(InputGenerator):
         ):
             return [
                 PackageRequest(ts=log.ts, package_title=self.package_title),
-                SharedFilesOperation(kind=SharedFilesOperationKind.FILE_DELETED),
+                SharedFilesOperation(
+                    kind=SharedFilesOperationKind.FILE_DELETED, count=1
+                ),
             ]
         else:
             return [PackageRequest(ts=log.ts, package_title=self.package_title)]
+
+
+@dataclass
+class FileManagerInputGenerator(InputGenerator):
+    """A specific generator for file-manger package"""
+
+    package_title: str
+
+    def process(self, log: LogData) -> list[Input]:
+        """Transform one log event identified as edupi into inputs"""
+        result: list[Input] = [
+            PackageRequest(ts=log.ts, package_title=self.package_title)
+        ]
+        if log.x_tfm_files_added:
+            result.append(
+                SharedFilesOperation(
+                    kind=SharedFilesOperationKind.FILE_CREATED,
+                    count=log.x_tfm_files_added,
+                )
+            )
+        if log.x_tfm_files_deleted:
+            result.append(
+                SharedFilesOperation(
+                    kind=SharedFilesOperationKind.FILE_DELETED,
+                    count=log.x_tfm_files_deleted,
+                )
+            )
+        return result
 
 
 @dataclass

--- a/backend/src/offspot_metrics_backend/business/inputs/input.py
+++ b/backend/src/offspot_metrics_backend/business/inputs/input.py
@@ -14,3 +14,11 @@ class TimedInput(Input):
 
     # moment where the input occured
     ts: datetime.datetime
+
+
+@dataclass(eq=True, frozen=True)
+class CountInput(Input):
+    """An input with a number of items"""
+
+    # number of items
+    count: int

--- a/backend/src/offspot_metrics_backend/business/inputs/shared_files.py
+++ b/backend/src/offspot_metrics_backend/business/inputs/shared_files.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from enum import Enum
 
-from offspot_metrics_backend.business.inputs.input import Input
+from offspot_metrics_backend.business.inputs.input import CountInput
 
 
 class SharedFilesOperationKind(str, Enum):
@@ -12,8 +12,11 @@ class SharedFilesOperationKind(str, Enum):
 
 
 @dataclass(eq=True, frozen=True)
-class SharedFilesOperation(Input):
-    """Input representing an operation on a shared files software (EduPi for now)"""
+class SharedFilesOperation(CountInput):
+    """Input representing an operation on a shared files software
+
+    Both EduPi and file-manager are supported for now
+    """
 
     # kind of operation (creation or deletion for now)
     kind: SharedFilesOperationKind

--- a/backend/src/offspot_metrics_backend/business/log_data.py
+++ b/backend/src/offspot_metrics_backend/business/log_data.py
@@ -15,3 +15,5 @@ class LogData:
     uri: str
     method: str
     ts: datetime.datetime
+    x_tfm_files_added: int | None  # files added in tiny file manager
+    x_tfm_files_deleted: int | None  # files deleted in tiny file manager

--- a/backend/src/offspot_metrics_backend/business/log_watcher.py
+++ b/backend/src/offspot_metrics_backend/business/log_watcher.py
@@ -73,7 +73,7 @@ class LogWatcherHandler(FileSystemEventHandler):
                         NewLineEvent(file_path=file_path, line_content=line.strip())
                     )
                 except Exception as exc:
-                    logger.warn(
+                    logger.warning(
                         f"Error occured while processing line in {file_path} at"
                         f" {self.file_positions_map[str(file_path)]}",
                         exc_info=exc,
@@ -87,7 +87,7 @@ class LogWatcherHandler(FileSystemEventHandler):
         try:
             self.process_event(event)
         except Exception as exc:  # pragma: no cover
-            logger.warn(
+            logger.warning(
                 f"Error occured while processing event {event.event_type} on"
                 f" {event.src_path}",
                 exc_info=exc,

--- a/backend/src/offspot_metrics_backend/business/processor.py
+++ b/backend/src/offspot_metrics_backend/business/processor.py
@@ -90,7 +90,7 @@ class Processor:
                 try:
                     self.process_input(input_=input_)
                 except Exception as exc:
-                    logger.warn("Error processing input", exc_info=exc)
+                    logger.warning("Error processing input", exc_info=exc)
 
     @dbsession
     def check_for_inactivity(self, session: Session):
@@ -131,7 +131,7 @@ class Processor:
             logger.debug("Generating a clock tick")
             self.process_input(ClockTick(ts=now))
         except Exception as exc:
-            logger.warn("Exception occured in clock tick", exc_info=exc)
+            logger.warning("Exception occured in clock tick", exc_info=exc)
 
         # Perform what needs to be done with indicators
         tick_period = Period(now)

--- a/backend/src/offspot_metrics_backend/main.py
+++ b/backend/src/offspot_metrics_backend/main.py
@@ -92,7 +92,7 @@ class Main:
             try:
                 self.processor.check_for_inactivity()
             except Exception as exc:
-                logger.warn(
+                logger.warning(
                     "Exception occured in check for inactivity tick", exc_info=exc
                 )
 
@@ -107,7 +107,7 @@ class Main:
             result = self.converter.process(event.line_content)
             self.processor.process_inputs(result=result)
         except Exception as exc:
-            logger.warn("Error log event", exc_info=exc)
+            logger.warning("Error log event", exc_info=exc)
 
     def create_app(self) -> FastAPI:
         self.app = FastAPI(

--- a/backend/tests/unit/business/test_log_converter.py
+++ b/backend/tests/unit/business/test_log_converter.py
@@ -62,13 +62,17 @@ from offspot_metrics_backend.business.reverse_proxy_config import ReverseProxyCo
                 ),
             ],
         ),
+        # ===============
+        # Edupi
         (
             r"""{"level":"info","msg":"handled request","status":"201","""
             r""""request":{"host":"edupi1.renaud.test","method":"POST","""
             r""""uri":"/api/documents/"},"resp_headers":{},"""
             r""""ts":1688459792.8632474}""",
             [
-                SharedFilesOperation(kind=SharedFilesOperationKind.FILE_CREATED),
+                SharedFilesOperation(
+                    kind=SharedFilesOperationKind.FILE_CREATED, count=1
+                ),
                 PackageRequest(
                     ts=datetime.datetime.fromtimestamp(1688459792.8632474),
                     package_title="Shared files 1",
@@ -81,7 +85,9 @@ from offspot_metrics_backend.business.reverse_proxy_config import ReverseProxyCo
             r""""uri":"/api/documents/123"},"resp_headers":{},"""
             r""""ts":1688459792.8632474}""",
             [
-                SharedFilesOperation(kind=SharedFilesOperationKind.FILE_DELETED),
+                SharedFilesOperation(
+                    kind=SharedFilesOperationKind.FILE_DELETED, count=1
+                ),
                 PackageRequest(
                     ts=datetime.datetime.fromtimestamp(1688459792.8632474),
                     package_title="Shared files 2",
@@ -185,6 +191,64 @@ from offspot_metrics_backend.business.reverse_proxy_config import ReverseProxyCo
             r""""uri":"/api/documents/123"},"resp_headers":{},"""
             r""""ts":1688459792.8632474}""",
             [],
+        ),
+        # ===============
+        # tiny-file-manager
+        (
+            r"""{"level":"info","msg":"handled request","status":"302","""
+            r""""request":{"host":"filemanager1.renaud.test","method":"POST","""
+            r""""uri":"/admin/index.php?p="},"""
+            r""""resp_headers":{"X-Tfm-Files-Added":["12"]},"""
+            r""""ts":1688459792.8632474}""",
+            [
+                SharedFilesOperation(
+                    kind=SharedFilesOperationKind.FILE_CREATED, count=12
+                ),
+                PackageRequest(
+                    ts=datetime.datetime.fromtimestamp(1688459792.8632474),
+                    package_title="Shared files - fm1",
+                ),
+            ],
+        ),
+        (
+            r"""{"level":"info","msg":"handled request","status":"302","""
+            r""""request":{"host":"filemanager2.renaud.test","method":"POST","""
+            r""""uri":"/admin/index.php?p="},"""
+            r""""resp_headers":{"X-Tfm-Files-Deleted":["22"]},"""
+            r""""ts":1688459792.8632474}""",
+            [
+                SharedFilesOperation(
+                    kind=SharedFilesOperationKind.FILE_DELETED, count=22
+                ),
+                PackageRequest(
+                    ts=datetime.datetime.fromtimestamp(1688459792.8632474),
+                    package_title="Shared files - fm2",
+                ),
+            ],
+        ),
+        (
+            r"""{"level":"info","msg":"handled request","status":"200","""
+            r""""request":{"host":"filemanager2.renaud.test","method":"GET","""
+            r""""uri":"/admin/index.php?p="},"resp_headers":{},"""
+            r""""ts":1688459793.8632474}""",
+            [
+                PackageRequest(
+                    ts=datetime.datetime.fromtimestamp(1688459793.8632474),
+                    package_title="Shared files - fm2",
+                )
+            ],
+        ),
+        (
+            r"""{"level":"info","msg":"handled request","status":"300","""
+            r""""request":{"host":"filemanager1.renaud.test","method":"POST","""
+            r""""uri":"/admin/index.php?p="},"resp_headers":{},"""
+            r""""ts":1688459794.8632474}""",
+            [
+                PackageRequest(
+                    ts=datetime.datetime.fromtimestamp(1688459794.8632474),
+                    package_title="Shared files - fm1",
+                )
+            ],
         ),
         (
             r"""{"level":"info","msg":"handled request","request":{"host":"""

--- a/backend/tests/unit/business/test_packages_config.py
+++ b/backend/tests/unit/business/test_packages_config.py
@@ -76,6 +76,16 @@ def test_parsing_ok(reverse_proxy_config: Callable[[str | None], ReverseProxyCon
             host="wikifundi.renaud.test",
             ident="wikifundi-en.offspot.kiwix.org",
         ),
+        AppConfig(
+            title="Shared files - fm1",
+            host="filemanager1.renaud.test",
+            ident="file-manager.offspot.kiwix.org",
+        ),
+        AppConfig(
+            title="Shared files - fm2",
+            host="filemanager2.renaud.test",
+            ident="file-manager.offspot.kiwix.org",
+        ),
     }
 
 

--- a/backend/tests/unit/conf_files/conf_ok.yaml
+++ b/backend/tests/unit/conf_files/conf_ok.yaml
@@ -67,3 +67,11 @@ packages:
   ident: wikifundi-en.offspot.kiwix.org
   title: Wikifundi
   url: //wikifundi.renaud.test/
+- kind: app
+  ident: file-manager.offspot.kiwix.org
+  title: Shared files - fm1
+  url: //filemanager1.renaud.test/
+- kind: app
+  ident: file-manager.offspot.kiwix.org
+  title: Shared files - fm2
+  url: //filemanager2.renaud.test/

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -73,17 +73,18 @@ services:
       - reverse-proxy-srv:/srv
     ports:
       - 127.0.0.1:8000:80
-  edupi:
-    container_name: om_edupi
-    image: ghcr.io/offspot/edupi:dev
+  file-manager:
+    container_name: om_file-manager
+    image: ghcr.io/offspot/file-manager:dev
     ports:
       - 127.0.0.1:8004:80
     volumes:
-      - edupi-data:/data
+      - file-manager-data:/data
     environment:
       ADMIN_USERNAME: admin
       ADMIN_PASSWORD: admin
+      ACCESS_MODE: mixed
 volumes:
   reverse-proxy-srv:
   logwatcher-data:
-  edupi-data:
+  file-manager-data:

--- a/dev/file-browser-data/home/index.html
+++ b/dev/file-browser-data/home/index.html
@@ -13,5 +13,7 @@
         <a href="//kiwix.localhost:8000/viewer#sqa.stackexchange.com_en_all_2023-05">Software Quality Assurance and Testing</a>
         <br>
         <a href="//kiwix.localhost:8000/viewer#devops.stackexchange.com_en_all_2023-05">DevOps</a>
+        <br>
+        <a href="//filemanager.localhost:8000">File manager</a>
 	</body>
 </html>

--- a/dev/reverse-proxy/config/Caddyfile
+++ b/dev/reverse-proxy/config/Caddyfile
@@ -29,6 +29,6 @@ kiwix.localhost:80 {
     reverse_proxy om_kiwix:80
 }
 
-edupi.localhost:80 {
-    reverse_proxy om_edupi:80
+filemanager.localhost:80 {
+    reverse_proxy om_file-manager:80
 }


### PR DESCRIPTION
## Rationale

Fix #104

## Changes

- replace `log.warn` (deprecated) by `log.warning`
- add new `FileManagerInputGenerator` to support file-manager logs
- add `x-tfm-files-added` and `x-tfm-files-deleted` to log data (so that it is parsed automatically / asap)
- create new `CountInput` base class which is an input with a `count` of items, and the associated `CountCounterRecorder` which is summing the `count` of all inputs, instead of just increasing a counter by 1 for each input received
- modify the `SharedFilesOperations` indicator to use new `CountCounterRecorder`
- modify the `SharedFilesOperation` input to inherit the new `CountInput` base class
- adapt the `dev` docker-compose configuration to use file-manager instead of EduPi
