### PR TITLE
"Tick processing started" log message now DEBUG instead of INFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- "Tick processing started" log message now DEBUG instead of INFO 
+
 ## [0.3.0] - 2024-02-05
 
 ### Added

--- a/backend/src/offspot_metrics_backend/business/processor.py
+++ b/backend/src/offspot_metrics_backend/business/processor.py
@@ -123,7 +123,7 @@ class Processor:
                 self.last_action = now
 
     def _process_tick(self, now: datetime.datetime, session: Session):
-        logger.info("Tick processing started")
+        logger.debug("Tick processing started")
         self.last_tick_processed = Tick(now)
 
         # Generate a ClockTick input


### PR DESCRIPTION
It's useless in production and fills up log because it's called constantly
